### PR TITLE
fix: calibration median, NVS dirty masks, NaN check (v10.2.1)

### DIFF
--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.2.0
+**Firmware version:** 10.2.1
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.2.0</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.2.1</text>
 </svg>

--- a/Documentation/user-manual/images/health-ui.svg
+++ b/Documentation/user-manual/images/health-ui.svg
@@ -2,7 +2,7 @@
   <rect x="0" y="0" width="128" height="128" fill="#000000" stroke="#ffffff" stroke-width="1"/>
   <text x="3" y="15" font-family="monospace" font-size="10" fill="#ffffff">System Health</text>
 
-  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.2.0</text>
+  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.2.1</text>
   <text x="4" y="40" font-family="monospace" font-size="6" fill="#ffffff">Prefs: v2 OK</text>
   <text x="4" y="50" font-family="monospace" font-size="6" fill="#ffffff">LiDAR: OK On err:0</text>
   <text x="4" y="60" font-family="monospace" font-size="6" fill="#ffffff">Recoveries: 0</text>

--- a/Documentation/user-manual/images/web-updater-ui.svg
+++ b/Documentation/user-manual/images/web-updater-ui.svg
@@ -11,10 +11,10 @@
 
   <rect x="200" y="245" width="1040" height="110" rx="16" fill="#f8fafc" stroke="#e2e8f0" stroke-width="2"/>
   <text x="230" y="286" font-family="IBM Plex Mono, monospace" font-size="24" fill="#111827">
-    Latest Build: 10.2.0
+    Latest Build: 10.2.1
   </text>
   <text x="230" y="325" font-family="IBM Plex Mono, monospace" font-size="24" fill="#111827">
-    Version To Install: 10.2.0 (Latest)
+    Version To Install: 10.2.1 (Latest)
   </text>
 
   <rect x="200" y="375" width="420" height="64" rx="10" fill="#111827"/>

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.2.1 - 2026-03-14
+
+- Bug fixes:
+  - Fixed calibration median index off-by-one: used lower median `(sample_count - 1) / 2` instead of upper median `sample_count / 2` for even sample counts.
+  - Replaced `ev_readout == ev_readout` NaN self-comparison with explicit `isnan()` for clarity and robustness against `-ffast-math`.
+- NVS flash wear reduction:
+  - All `savePrefs()` calls in `cyclefuncs.cpp` now pass `PREFS_DIRTY_SETTINGS` instead of defaulting to `PREFS_DIRTY_ALL`.
+- Release metadata/docs:
+  - Bumped `FWVERSION` to `10.2.1`.
+  - Updated firmware README, user manual, and camera UI SVG snapshots.
+
 ## 10.2.0 - 2026-02-28
 
 - Power and runtime efficiency:

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.2.0  
+**Version**: 10.2.1
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.2.0"                  // Version shown in UI and release metadata.
+#define FWVERSION "10.2.1"                  // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------

--- a/Firmware/src/calibration_logic.cpp
+++ b/Firmware/src/calibration_logic.cpp
@@ -45,7 +45,7 @@ bool computeStableCalibrationReading(
     sorted[i] = samples[i];
   }
   sortAscending(sorted, sample_count);
-  const int median = sorted[sample_count / 2];
+  const int median = sorted[(sample_count - 1) / 2];
 
   long inlierSum = 0;
   int inlierCount = 0;

--- a/Firmware/src/cyclefuncs.cpp
+++ b/Firmware/src/cyclefuncs.cpp
@@ -127,14 +127,14 @@ void cycleApertures(CycleDirection direction)
     if (lenses[selected_lens].apertures[aperture_index] != 0)
     {
       aperture = lenses[selected_lens].apertures[aperture_index];
-      savePrefs();
+      savePrefs(false, PREFS_DIRTY_SETTINGS);
       return;
     }
   }
 
   aperture_index = 0;
   aperture = lenses[selected_lens].apertures[aperture_index];
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleISOs()
@@ -145,7 +145,7 @@ void cycleISOs()
     iso_index = 0;
   }
   iso = ISOS[iso_index];
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleLenses()
@@ -165,7 +165,7 @@ void cycleLenses()
     }
   } while (!lenses[selected_lens].calibrated);
 
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleCalibLenses()
@@ -186,7 +186,7 @@ void cycleFormats()
   {
     selected_format = 0;
   }
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleCurrentFrame()
@@ -240,7 +240,7 @@ void cycleExposureCompensation(CycleDirection direction)
   {
     exposure_comp_thirds = LIGHTMETER_EV_COMP_MAX_THIRDS;
   }
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleMeterSmoothing()
@@ -250,43 +250,43 @@ void cycleMeterSmoothing()
   {
     meter_smoothing_mode = LIGHTMETER_SMOOTHING_MODE_MIN;
   }
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void toggleEvReadout()
 {
   show_ev_readout = !show_ev_readout;
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleLevelTrimLandscape()
 {
   level_trim_landscape_deci_deg = cycleLevelTrimValue(level_trim_landscape_deci_deg);
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleLevelTrimPortraitPos()
 {
   level_trim_portrait_pos_deci_deg = cycleLevelTrimValue(level_trim_portrait_pos_deci_deg);
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleLevelTrimPortraitNeg()
 {
   level_trim_portrait_neg_deci_deg = cycleLevelTrimValue(level_trim_portrait_neg_deci_deg);
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleSleepTimeoutMode()
 {
   sleep_timeout_mode = cycleSleepTimeoutModeValue(sleep_timeout_mode);
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 void cycleLidarIdleTimeoutMode()
 {
   lidar_idle_timeout_mode = cycleSleepTimeoutModeValue(lidar_idle_timeout_mode);
-  savePrefs();
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
 const char *getSleepTimeoutModeLabel(int timeout_mode)

--- a/Firmware/src/interface.cpp
+++ b/Firmware/src/interface.cpp
@@ -303,7 +303,7 @@ void drawMainHeader()
     getCompactShutterDisplay(shutter_speed, compactShutter, sizeof(compactShutter));
     u8g2.print(compactShutter);
     u8g2.print(F(" EV"));
-    if (ev_readout == ev_readout)
+    if (!isnan(ev_readout))
     {
       u8g2.print(ev_readout, 1);
     }

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -1,4 +1,4 @@
-// IDENTIDEM.design Medium Format Rangefinder firmware v10.2.0
+// IDENTIDEM.design Medium Format Rangefinder firmware v10.2.1
 // Hardware: DTS6012M LiDAR, STEMMA I2C QT Rotary Encoder (4991), SH1107 main + SSD1306 external OLEDs
 
 #include <Arduino.h>


### PR DESCRIPTION
## Summary
- **Calibration median index**: fixed off-by-one in `computeStableCalibrationReading()` — was using upper median (index 4 of 8) instead of lower median (index 3), biasing the outlier filter pivot slightly high.
- **NVS dirty masks**: all `savePrefs()` calls in `cyclefuncs.cpp` now pass `PREFS_DIRTY_SETTINGS` instead of defaulting to `PREFS_DIRTY_ALL`, reducing unnecessary flash writes.
- **EV readout NaN check**: replaced `ev_readout == ev_readout` self-comparison idiom with explicit `isnan()` for clarity and robustness against `-ffast-math`.
- Bumps firmware version to 10.2.1.

## Test plan
- [x] All 29 native tests pass (`pio test -e native_core_tests`)
- [x] Verify calibration flow produces consistent readings on device
- [x] Confirm EV readout shows `--.-` when light meter is unavailable
- [x] Check NVS write count doesn't spike when cycling settings