### PR TITLE
Add visual focus reticle offset adjustment

### DIFF
--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -240,7 +240,19 @@ Current frame ranges are format-bound:
 3. **Horizon Portrait-**: portrait trim offset for the opposite portrait side (`-30deg` to `+30deg`, `2.5deg` steps, default `0deg`).
 4. **Sleep timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m30s`).
 5. **LiDAR idle timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m`).
-6. **Back <<**: return to setup root menu.
+6. **Focus reticle >**: enter visual reticle offset adjustment (see below).
+7. **Back <<**: return to setup root menu.
+
+#### Focus reticle adjustment
+
+![Focus reticle adjustment](images/config-reticle-adjust.svg)
+
+This screen lets you visually align the focus reticle to the camera's optical centre. Only the reticle dot is shown on an otherwise blank screen.
+
+1. **Horizontal**: press **L** to move left, **R** to move right. **Long press either button** to advance to vertical adjustment.
+2. **Vertical**: press **L** to move up, **R** to move down. **Long press either button** to save the new offsets and return to UI Settings.
+
+Offsets are stored in non-volatile memory and survive reboots. Range: -20 to +20 pixels in each axis.
 
 ### System Health screen
 

--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.3.2
+**Firmware version:** 10.4.0
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 

--- a/Documentation/user-manual/images/config-reticle-adjust.svg
+++ b/Documentation/user-manual/images/config-reticle-adjust.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 128 128">
+  <rect x="0" y="0" width="128" height="128" fill="#000000" stroke="#ffffff" stroke-width="1"/>
+  <circle cx="59" cy="59" r="3" fill="#ffffff"/>
+  <text x="2" y="122" font-family="monospace" font-size="6" fill="#ffffff">(L)&lt;  &gt;(R)  hold:next</text>
+</svg>

--- a/Documentation/user-manual/images/config-ui-settings.svg
+++ b/Documentation/user-manual/images/config-ui-settings.svg
@@ -9,5 +9,6 @@
   <text x="4" y="44" font-family="monospace" font-size="6" fill="#ffffff"> Horizon Portrait-:0deg </text>
   <text x="4" y="53" font-family="monospace" font-size="6" fill="#ffffff"> Sleep timeout: 1m30s</text>
   <text x="4" y="62" font-family="monospace" font-size="6" fill="#ffffff"> LiDAR idle: 1m </text>
-  <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> Back &lt;&lt; </text>
+  <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> Focus reticle &gt; </text>
+  <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Back &lt;&lt; </text>
 </svg>

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.3.0</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.4.0</text>
 </svg>

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.4.0 - 2026-04-15
+
+- Add visual focus reticle offset adjustment (Setup > UI Settings > Focus reticle).
+  - Step 1: L/R moves reticle horizontally; long press either button advances to step 2.
+  - Step 2: L/R moves reticle vertically; long press either button saves and exits.
+  - Offsets persisted to NVS and survive reboots. Range: -20 to +20 px.
+- Reticle offset X/Y converted from compile-time constants to user-configurable settings.
+
 ## 10.3.5 - 2026-04-02
 
 - Reduce focus ring granularity from 1cm to 5cm steps so the ring locks when lidar and lens distances visually match, without snapping too early.

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable firmware changes by released `FWVERSION`, reconstructed from git his
   - Step 2: L/R moves reticle vertically; long press either button saves and exits.
   - Offsets persisted to NVS and survive reboots. Range: -20 to +20 px.
 - Reticle offset X/Y converted from compile-time constants to user-configurable settings.
+- Fix right-button long press firing repeatedly on every loop iteration; it now fires exactly once per hold across all modes.
 
 ## 10.3.5 - 2026-04-02
 

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -186,6 +186,7 @@ pio test -e native_core_tests
 - `FWVERSION`: Firmware version string
 - `DEFAULT_SLEEP_TIMEOUT_MODE` / `SLEEP_TIMEOUT_MODE_*`: Auto-sleep options (`Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m`; default `1m30s`)
 - `DEFAULT_LIDAR_IDLE_TIMEOUT_MODE`: Awake-main LiDAR standby timeout default (`1m`)
+- `DEFAULT_RETICLE_OFFSET_X` / `DEFAULT_RETICLE_OFFSET_Y`: Reticle position offsets (default `-5`, `0`; range `-20` to `+20` px)
 - `SMOOTHING_WINDOW_SIZE`: Filter window (13 samples)
 - `LENS_INF_THRESHOLD`: Infinity focus threshold
 - `LIDAR_LIBRARY_DISTANCE_SCALE`: LiDAR library distance scaling factor

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.3.2
+**Version**: 10.4.0
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 
@@ -213,6 +213,7 @@ The system saves:
 - Sleep timeout mode
 - LiDAR idle timeout mode
 - UI horizon trim offsets (landscape, portrait `P+`, portrait `P-`)
+- Reticle offset X/Y
 - Light-meter EV/smoothing/readout settings
 - Lens calibration data
 

--- a/Firmware/include/globals.h
+++ b/Firmware/include/globals.h
@@ -16,7 +16,8 @@ enum class UiMode : uint8_t
   Calib,
   ResetConfirm,
   Health,
-  FactoryResetConfirm
+  FactoryResetConfirm,
+  ReticleAdjust
 };
 
 // Preferences
@@ -43,6 +44,8 @@ extern int lidar_idle_timeout_mode;
 extern int level_trim_landscape_deci_deg;
 extern int level_trim_portrait_pos_deci_deg;
 extern int level_trim_portrait_neg_deci_deg;
+extern int reticle_offset_x;
+extern int reticle_offset_y;
 
 // Filter algorithm
 extern int samples[SMOOTHING_WINDOW_SIZE];
@@ -70,6 +73,7 @@ extern int bat_per;
 extern UiMode ui_mode;
 extern int config_step;
 extern int calib_step;
+extern int reticle_adjust_step; // 0 = horizontal, 1 = vertical
 extern int selected_lens;
 extern int selected_format;
 extern int calib_lens;

--- a/Firmware/include/interface.h
+++ b/Firmware/include/interface.h
@@ -14,6 +14,7 @@ void drawCalibCompleteUI();
 void drawResetConfirmUI();
 void drawFactoryResetConfirmUI();
 void drawHealthUI();
+void drawReticleAdjustUI();
 void drawExternalUI();
 void drawSleepUI();
 // ---------------------

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.3.5"                  // Version shown in UI and release metadata.
+#define FWVERSION "10.4.0"                  // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------
@@ -113,8 +113,10 @@ const int CM_PER_METER = 100; // Centimeters per meter.
 // ---------------------------------------------------------------------------
 // LiDAR fusion and confidence pipeline tuning
 // ---------------------------------------------------------------------------
-#define RETICLE_OFFSET_X -5 // Main reticle X offset for optical alignment.
-#define RETICLE_OFFSET_Y 0  // Main reticle Y offset for optical alignment.
+const int DEFAULT_RETICLE_OFFSET_X = -5; // Default reticle X offset for optical alignment.
+const int DEFAULT_RETICLE_OFFSET_Y = 0;  // Default reticle Y offset for optical alignment.
+const int RETICLE_OFFSET_MIN = -20;      // Minimum reticle offset in pixels.
+const int RETICLE_OFFSET_MAX = 20;       // Maximum reticle offset in pixels.
 const int LIDAR_DISTANCE_DIVISOR = 10;           // Raw LiDAR millimetre-to-centimetre divisor.
 const uint16_t LIDAR_FRAME_RATE_FPS = 50;        // Sensor frame rate — lower = more integration time per frame.
 const unsigned long LIDAR_NO_DATA_TIMEOUT_MS = 1000; // Hold last reading before showing placeholder.
@@ -365,6 +367,7 @@ enum ConfigUiStep
   CONFIG_UI_STEP_HORIZON_PORTRAIT_NEG,   // Portrait - horizon trim.
   CONFIG_UI_STEP_SLEEP_TIMEOUT,          // Sleep timeout selector.
   CONFIG_UI_STEP_LIDAR_IDLE_TIMEOUT,     // LiDAR idle-timeout selector.
+  CONFIG_UI_STEP_RETICLE_ADJUST,         // Enter reticle offset adjustment.
   CONFIG_UI_STEP_BACK,                   // Back to setup root.
   CONFIG_UI_STEP_COUNT
 };

--- a/Firmware/src/globals.cpp
+++ b/Firmware/src/globals.cpp
@@ -26,6 +26,8 @@ int lidar_idle_timeout_mode = DEFAULT_LIDAR_IDLE_TIMEOUT_MODE;
 int level_trim_landscape_deci_deg = DEFAULT_LEVEL_TRIM_LANDSCAPE_DECI_DEG;
 int level_trim_portrait_pos_deci_deg = DEFAULT_LEVEL_TRIM_PORTRAIT_POS_DECI_DEG;
 int level_trim_portrait_neg_deci_deg = DEFAULT_LEVEL_TRIM_PORTRAIT_NEG_DECI_DEG;
+int reticle_offset_x = DEFAULT_RETICLE_OFFSET_X;
+int reticle_offset_y = DEFAULT_RETICLE_OFFSET_Y;
 
 // Filter algorithm
 int samples[SMOOTHING_WINDOW_SIZE];
@@ -53,6 +55,7 @@ int bat_per = 0;
 UiMode ui_mode = UiMode::Main;
 int config_step = 0;
 int calib_step = 0;
+int reticle_adjust_step = 0;
 int selected_lens = DEFAULT_SELECTED_LENS;
 int selected_format = DEFAULT_SELECTED_FORMAT;
 int calib_lens = 0;

--- a/Firmware/src/helpers.cpp
+++ b/Firmware/src/helpers.cpp
@@ -70,6 +70,8 @@ void writeSettingsPrefs()
   prefs.putInt("lvl_trim_l10", level_trim_landscape_deci_deg);
   prefs.putInt("lvl_trim_pp10", level_trim_portrait_pos_deci_deg);
   prefs.putInt("lvl_trim_pn10", level_trim_portrait_neg_deci_deg);
+  prefs.putInt("reticle_x", reticle_offset_x);
+  prefs.putInt("reticle_y", reticle_offset_y);
 }
 
 void writeFilmPrefs()
@@ -198,6 +200,9 @@ void clampLoadedState()
   level_trim_portrait_pos_deci_deg = snapLevelTrimDeciDeg(level_trim_portrait_pos_deci_deg);
   level_trim_portrait_neg_deci_deg = snapLevelTrimDeciDeg(level_trim_portrait_neg_deci_deg);
 
+  reticle_offset_x = constrain(reticle_offset_x, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+  reticle_offset_y = constrain(reticle_offset_y, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+
   frame_one_offset = constrain(frame_one_offset, FRAME_TUNING_MIN, FRAME_TUNING_MAX);
   frame_spacing_offset = constrain(frame_spacing_offset, FRAME_TUNING_MIN, FRAME_TUNING_MAX);
 }
@@ -300,6 +305,8 @@ void loadPrefs()
   level_trim_landscape_deci_deg = prefs.getInt("lvl_trim_l10", legacy_trim_l * 10);
   level_trim_portrait_pos_deci_deg = prefs.getInt("lvl_trim_pp10", legacy_trim_pp * 10);
   level_trim_portrait_neg_deci_deg = prefs.getInt("lvl_trim_pn10", legacy_trim_pn * 10);
+  reticle_offset_x = prefs.getInt("reticle_x", DEFAULT_RETICLE_OFFSET_X);
+  reticle_offset_y = prefs.getInt("reticle_y", DEFAULT_RETICLE_OFFSET_Y);
   film_counter = prefs.getInt("film_counter", 0);
   encoder_value = prefs.getInt("encoder_value", 0);
   prev_encoder_value = prefs.getInt("prev_encoder_value", 0);

--- a/Firmware/src/inputs.cpp
+++ b/Firmware/src/inputs.cpp
@@ -247,6 +247,15 @@ void handleReticleAdjustLongPress()
   }
 }
 
+void handleLeftButtonLongPress()
+{
+  registerActivity();
+  if (ui_mode == UiMode::ReticleAdjust)
+  {
+    handleReticleAdjustLongPress();
+  }
+}
+
 void handleRightButtonLongPress()
 {
   registerActivity();
@@ -453,12 +462,10 @@ void checkButtons()
   static bool rbuttonLongHandled = false;
 
   lbutton.update();
-  if (lbutton.isPressed() && lbutton.currentDuration() >= BUTTON_LONG_PRESS_MIN_MS &&
-      ui_mode == UiMode::ReticleAdjust && !lbuttonLongHandled)
+  if (lbutton.isPressed() && lbutton.currentDuration() >= BUTTON_LONG_PRESS_MIN_MS && !lbuttonLongHandled)
   {
     lbuttonLongHandled = true;
-    registerActivity();
-    handleReticleAdjustLongPress();
+    handleLeftButtonLongPress();
   }
   else if (lbutton.rose())
   {

--- a/Firmware/src/inputs.cpp
+++ b/Firmware/src/inputs.cpp
@@ -120,6 +120,17 @@ void handleLeftButtonShortPress()
   {
     advanceMenuStep(CONFIG_UI_STEP_MAX);
   }
+  else if (ui_mode == UiMode::ReticleAdjust)
+  {
+    if (reticle_adjust_step == 0)
+    {
+      reticle_offset_x = constrain(reticle_offset_x - 1, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+    }
+    else
+    {
+      reticle_offset_y = constrain(reticle_offset_y - 1, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+    }
+  }
   else if (ui_mode == UiMode::Calib)
   {
     if (calib_step == 0)
@@ -222,6 +233,20 @@ void handleLeftButtonShortPress()
   }
 }
 
+void handleReticleAdjustLongPress()
+{
+  if (reticle_adjust_step == 0)
+  {
+    reticle_adjust_step = 1;
+  }
+  else
+  {
+    savePrefs(false, PREFS_DIRTY_SETTINGS);
+    config_step = CONFIG_UI_STEP_RETICLE_ADJUST;
+    ui_mode = UiMode::ConfigUi;
+  }
+}
+
 void handleRightButtonLongPress()
 {
   registerActivity();
@@ -232,6 +257,10 @@ void handleRightButtonLongPress()
   else if (ui_mode == UiMode::Health)
   {
     ui_mode = UiMode::FactoryResetConfirm;
+  }
+  else if (ui_mode == UiMode::ReticleAdjust)
+  {
+    handleReticleAdjustLongPress();
   }
 }
 
@@ -359,9 +388,24 @@ void handleRightButtonShortPress()
     else if (config_step == CONFIG_UI_STEP_LIDAR_IDLE_TIMEOUT) {
       cycleLidarIdleTimeoutMode();
     }
+    else if (config_step == CONFIG_UI_STEP_RETICLE_ADJUST) {
+      reticle_adjust_step = 0;
+      ui_mode = UiMode::ReticleAdjust;
+    }
     else if (config_step == CONFIG_UI_STEP_BACK) {
       config_step = CONFIG_ROOT_STEP_UI_MENU;
       ui_mode = UiMode::Config;
+    }
+  }
+  else if (ui_mode == UiMode::ReticleAdjust)
+  {
+    if (reticle_adjust_step == 0)
+    {
+      reticle_offset_x = constrain(reticle_offset_x + 1, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+    }
+    else
+    {
+      reticle_offset_y = constrain(reticle_offset_y + 1, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
     }
   }
   else if (ui_mode == UiMode::Calib)
@@ -405,20 +449,39 @@ void handleRightButtonShortPress()
 
 void checkButtons()
 {
+  static bool lbuttonLongHandled = false;
+  static bool rbuttonLongHandled = false;
+
   lbutton.update();
-  if (lbutton.rose() && lbutton.previousDuration() < BUTTON_SHORT_PRESS_MAX_MS)
+  if (lbutton.isPressed() && lbutton.currentDuration() >= BUTTON_LONG_PRESS_MIN_MS &&
+      ui_mode == UiMode::ReticleAdjust && !lbuttonLongHandled)
   {
-    handleLeftButtonShortPress();
+    lbuttonLongHandled = true;
+    registerActivity();
+    handleReticleAdjustLongPress();
+  }
+  else if (lbutton.rose())
+  {
+    lbuttonLongHandled = false;
+    if (lbutton.previousDuration() < BUTTON_SHORT_PRESS_MAX_MS)
+    {
+      handleLeftButtonShortPress();
+    }
   }
 
   rbutton.update();
-  if (rbutton.isPressed() && rbutton.currentDuration() >= BUTTON_LONG_PRESS_MIN_MS)
+  if (rbutton.isPressed() && rbutton.currentDuration() >= BUTTON_LONG_PRESS_MIN_MS && !rbuttonLongHandled)
   {
+    rbuttonLongHandled = true;
     handleRightButtonLongPress();
   }
-  else if (rbutton.rose() && rbutton.previousDuration() < BUTTON_SHORT_PRESS_MAX_MS)
+  else if (rbutton.rose())
   {
-    handleRightButtonShortPress();
+    rbuttonLongHandled = false;
+    if (rbutton.previousDuration() < BUTTON_SHORT_PRESS_MAX_MS)
+    {
+      handleRightButtonShortPress();
+    }
   }
 }
 // ---------------------

--- a/Firmware/src/interface.cpp
+++ b/Firmware/src/interface.cpp
@@ -900,7 +900,7 @@ void drawReticleAdjustUI()
   // Draw only the reticle dot at its current offset position.
   int cx = (SCREEN_WIDTH / 2) + reticle_offset_x;
   int cy = (SCREEN_HEIGHT / 2) - MAIN_RETICLE_CENTER_Y_OFFSET + reticle_offset_y;
-  display.fillCircle(cx, cy, MAIN_RETICLE_CENTER_RADIUS, INVERSE);
+  display.fillCircle(cx, cy, MAIN_RETICLE_CENTER_RADIUS, WHITE);
 
   // Draw button labels at the bottom.
   u8g2.setFont(u8g2_font_4x6_mf);

--- a/Firmware/src/interface.cpp
+++ b/Firmware/src/interface.cpp
@@ -405,8 +405,8 @@ MainFramelineLayout buildMainFramelineLayout()
   layout.innerX = static_cast<int>(roundf(frameCenterX - (scaledWidth / 2.0f)));
   layout.innerY = static_cast<int>(roundf(frameCenterY - (scaledHeight / 2.0f)));
 
-  layout.reticleCenterX = (layout.baseX + (layout.width / 2)) + RETICLE_OFFSET_X;
-  layout.reticleCenterY = (layout.baseY + (layout.height / 2) - MAIN_RETICLE_CENTER_Y_OFFSET) + RETICLE_OFFSET_Y;
+  layout.reticleCenterX = (layout.baseX + (layout.width / 2)) + reticle_offset_x;
+  layout.reticleCenterY = (layout.baseY + (layout.height / 2) - MAIN_RETICLE_CENTER_Y_OFFSET) + reticle_offset_y;
 
   return layout;
 }
@@ -884,8 +884,36 @@ void drawUiConfigUI()
   u8g2.print(getSleepTimeoutModeLabel(lidar_idle_timeout_mode));
   u8g2.print(F(" "));
 
+  selectConfigMenuRow(CONFIG_UI_STEP_RETICLE_ADJUST, config_step == CONFIG_UI_STEP_RETICLE_ADJUST);
+  u8g2.print(F(" Focus reticle > "));
+
   selectConfigMenuRow(CONFIG_UI_STEP_BACK, config_step == CONFIG_UI_STEP_BACK);
   u8g2.print(F(" Back << "));
+
+  display.display();
+}
+
+void drawReticleAdjustUI()
+{
+  preparePrimaryDisplayTextMode();
+
+  // Draw only the reticle dot at its current offset position.
+  int cx = (SCREEN_WIDTH / 2) + reticle_offset_x;
+  int cy = (SCREEN_HEIGHT / 2) - MAIN_RETICLE_CENTER_Y_OFFSET + reticle_offset_y;
+  display.fillCircle(cx, cy, MAIN_RETICLE_CENTER_RADIUS, INVERSE);
+
+  // Draw button labels at the bottom.
+  u8g2.setFont(u8g2_font_4x6_mf);
+  if (reticle_adjust_step == 0)
+  {
+    u8g2.setCursor(2, 122);
+    u8g2.print(F("(L)<  >(R)  hold:next"));
+  }
+  else
+  {
+    u8g2.setCursor(2, 122);
+    u8g2.print(F("(L)^  v(R)  hold:save"));
+  }
 
   display.display();
 }

--- a/Firmware/src/loop_runtime.cpp
+++ b/Firmware/src/loop_runtime.cpp
@@ -126,6 +126,8 @@ uint32_t buildMainUiSignature()
   hash = hashInt(hash, lens_distance_raw);
   hash = hashInt(hash, lidar_quality_level);
   hash = hashBool(hash, parallaxEnabled);
+  hash = hashInt(hash, reticle_offset_x);
+  hash = hashInt(hash, reticle_offset_y);
   return hash;
 }
 
@@ -153,6 +155,9 @@ uint32_t buildMenuUiSignature()
   hash = hashInt(hash, level_trim_landscape_deci_deg);
   hash = hashInt(hash, level_trim_portrait_pos_deci_deg);
   hash = hashInt(hash, level_trim_portrait_neg_deci_deg);
+  hash = hashInt(hash, reticle_offset_x);
+  hash = hashInt(hash, reticle_offset_y);
+  hash = hashInt(hash, reticle_adjust_step);
   hash = hashInt(hash, frame_one_offset);
   hash = hashInt(hash, frame_spacing_offset);
   hash = hashInt(hash, film_counter);
@@ -624,6 +629,9 @@ void drawPrimaryUiForCurrentMode()
     break;
   case UiMode::FactoryResetConfirm:
     drawFactoryResetConfirmUI();
+    break;
+  case UiMode::ReticleAdjust:
+    drawReticleAdjustUI();
     break;
   }
 }


### PR DESCRIPTION
## Summary

- New UI screen (Setup > UI Settings > Focus reticle) for visually aligning the focus reticle to the camera's optical centre.
- Step 1: L/R adjusts horizontal position. Long press either button advances to step 2.
- Step 2: L/R adjusts vertical position. Long press either button saves offsets and exits.
- Reticle offsets converted from compile-time `#define` to NVS-persisted user settings (range -20 to +20 px, default -5, 0).
- Extracts `handleLeftButtonLongPress()` to mirror the right-button dispatch pattern; removes inline mode guard from `checkButtons()`.
- Fixes right-button long press firing repeatedly on every loop iteration — both buttons now fire exactly once per hold via handled flags.
- Uses `WHITE` instead of `INVERSE` for the reticle dot in the adjustment screen (display is cleared before drawing).
- Firmware bumped to 10.4.0.
- Updated user manual, changelog, firmware README, and UI SVGs (including version numbers).

## Test plan

- [x] Flash and enter Setup > UI Settings — confirm **Focus reticle >** appears before **Back <<**
- [x] Enter Focus reticle — confirm blank screen with white dot and `(L)<  >(R)  hold:next` label
- [x] L/R moves reticle horizontally; dot stays within ±20 px
- [x] Long press either button — label changes to `(L)^  v(R)  hold:save`
- [x] L/R moves reticle vertically; dot stays within ±20 px
- [x] Long press saves and returns to UI Settings with cursor on Focus reticle
- [x] Reboot — confirm offsets persist
- [x] Reticle position on main viewfinder screen reflects saved offsets
- [x] Hold right button on main screen — Config mode entered on first fire, not repeated
- [x] Left short press still navigates menus normally