### PR TITLE
Customer requests: near-distance precision, brightness, horizon toggle, settings preservation (v10.4.5)

### DIFF
--- a/.github/workflows/firmware-updater-pages.yml
+++ b/.github/workflows/firmware-updater-pages.yml
@@ -153,7 +153,7 @@ jobs:
           write_manifest() {
             local output_dir="$1"
             local fw_version="$2"
-            python3 -c 'import json,pathlib,sys; out_path=pathlib.Path(sys.argv[1]); fw_version=sys.argv[2]; payload={"name":"IDENTIDEM MRF2","version":fw_version,"new_install_prompt_erase":False,"new_install_improv_wait_time":0,"builds":[{"chipFamily":"ESP32-S3","parts":[{"path":"bootloader.bin","offset":0},{"path":"partitions.bin","offset":32768},{"path":"boot_app0.bin","offset":57344},{"path":"tinyuf2.bin","offset":2949120},{"path":"firmware.bin","offset":65536}]}]}; out_path.write_text(json.dumps(payload, indent=2)+"\n", encoding="utf-8")' "$output_dir/manifest.json" "$fw_version"
+            python3 -c 'import json,pathlib,sys; out_path=pathlib.Path(sys.argv[1]); fw_version=sys.argv[2]; payload={"name":"IDENTIDEM MRF2","version":fw_version,"new_install_prompt_erase":False,"new_install_improv_wait_time":0,"builds":[{"chipFamily":"ESP32-S3","parts":[{"path":"firmware.bin","offset":65536}],"new_install_parts":[{"path":"bootloader.bin","offset":0},{"path":"partitions.bin","offset":32768},{"path":"boot_app0.bin","offset":57344},{"path":"tinyuf2.bin","offset":2949120}]}]}; out_path.write_text(json.dumps(payload, indent=2)+"\n", encoding="utf-8")' "$output_dir/manifest.json" "$fw_version"
           }
 
           declare -A VERSION_SEEN=()

--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.4.0
+**Firmware version:** 10.4.5
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 
@@ -109,7 +109,7 @@ You can tune horizon trim offsets independently for **Horizon Landscape**, **Hor
   - Uses LiDAR v2 primary/secondary returns with confidence scoring and correction for more stable readings.
   - Confidence accounts for ambient sunlight relative to return intensity. Thresholds are tuned for outdoor use in bright conditions, and the sensor falls back to low-confidence tracking at all ranges when primary filtering rejects a return.
   - Measurement range: 5 cm to 18 m.
-  - Displays values below 1 meter in centimeters (for example, `75cm`), and 1 meter and above in meters.
+  - Displays values below 1 meter in centimeters (for example, `75cm`), 1m to below 2m in meters with two decimal places (for example, `1.85m`), and 2m and above with one decimal place (for example, `2.5m`).
   - Displays `Inf.` when the subject is beyond sensor range (last reading was above 3 m and signal is lost), or for readings above 10.5 metres.
   - Displays `...` if the sensor has no valid data for 1 second at close range.
   - Displays `Zzz` when LiDAR is in idle standby (wake by focusing or pressing a button).
@@ -238,10 +238,13 @@ Current frame ranges are format-bound:
 1. **Horizon Landscape**: landscape trim offset (`-30deg` to `+30deg`, `2.5deg` steps, default `0deg`).
 2. **Horizon Portrait+**: portrait trim offset for one portrait side (`-30deg` to `+30deg`, `2.5deg` steps, default `0deg`).
 3. **Horizon Portrait-**: portrait trim offset for the opposite portrait side (`-30deg` to `+30deg`, `2.5deg` steps, default `0deg`).
-4. **Sleep timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m30s`).
-5. **LiDAR idle timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m`).
-6. **Focus reticle >**: enter visual reticle offset adjustment (see below).
-7. **Back <<**: return to setup root menu.
+4. **Horizon line**: toggle the horizon/level indicator on the main viewfinder screen (`On`/`Off`, default `On`).
+5. **Bright mode**: display brightness mode (`Auto` scales with ambient light from the light meter; `Manual` sets a fixed level; default `Auto`).
+6. **Bright top** (if Auto): maximum brightness ceiling (`50%`–`100%` in `10%` steps, default `100%`). Displayed as **Bright level** if Manual: fixed brightness (`5%`–`100%` in `5%` steps, default `100%`).
+7. **Sleep timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m30s`).
+8. **LiDAR idle timeout**: cycles `Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m` (default `1m`).
+9. **Focus reticle >**: enter visual reticle offset adjustment (see below).
+10. **Back <<**: return to setup root menu.
 
 #### Focus reticle adjustment
 

--- a/Documentation/user-manual/images/config-ui-settings.svg
+++ b/Documentation/user-manual/images/config-ui-settings.svg
@@ -7,8 +7,11 @@
 
   <text x="4" y="35" font-family="monospace" font-size="6" fill="#ffffff"> Horizon Portrait+:0deg </text>
   <text x="4" y="44" font-family="monospace" font-size="6" fill="#ffffff"> Horizon Portrait-:0deg </text>
-  <text x="4" y="53" font-family="monospace" font-size="6" fill="#ffffff"> Sleep timeout: 1m30s</text>
-  <text x="4" y="62" font-family="monospace" font-size="6" fill="#ffffff"> LiDAR idle: 1m </text>
-  <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> Focus reticle &gt; </text>
-  <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Back &lt;&lt; </text>
+  <text x="4" y="53" font-family="monospace" font-size="6" fill="#ffffff"> Horizon line: On </text>
+  <text x="4" y="62" font-family="monospace" font-size="6" fill="#ffffff"> Bright mode: Auto </text>
+  <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> Bright top: 100% </text>
+  <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Sleep timeout: 1m30s</text>
+  <text x="4" y="89" font-family="monospace" font-size="6" fill="#ffffff"> LiDAR idle: 1m </text>
+  <text x="4" y="98" font-family="monospace" font-size="6" fill="#ffffff"> Focus reticle &gt; </text>
+  <text x="4" y="107" font-family="monospace" font-size="6" fill="#ffffff"> Back &lt;&lt; </text>
 </svg>

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.4.0</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.4.5</text>
 </svg>

--- a/Documentation/web-updater/README.md
+++ b/Documentation/web-updater/README.md
@@ -13,7 +13,7 @@ This repo includes a static firmware updater site in `docs/` that uses Web Seria
 ## How it works
 
 1. The GitHub Actions workflow `.github/workflows/firmware-updater-pages.yml` builds firmware from `Firmware/` using PlatformIO.
-2. The workflow copies required ESP32-S3 images into `firmware/latest/` inside the Pages artifact:
+2. The workflow copies all required ESP32-S3 images into each version directory:
    - `bootloader.bin` @ `0x0000` (Adafruit TinyUF2 bootloader)
    - `partitions.bin` @ `0x8000`
    - `boot_app0.bin` @ `0xE000`
@@ -26,6 +26,15 @@ This repo includes a static firmware updater site in `docs/` that uses Web Seria
    - `firmware/versions.json` catalog (used by the UI dropdown)
 5. The static app in `docs/` loads `firmware/versions.json`, defaults the selector to the latest entry, and points ESP Web Tools to the selected manifest.
 6. The release notes panel shows notes for the selected version and the immediately previous version, with a link to the full changelog.
+
+## Flash behaviour: updates vs new installs
+
+The manifest uses ESP Web Tools' `new_install_parts` feature to preserve camera settings on firmware updates:
+
+- **Firmware update** (device already has MRF2 firmware): only `firmware.bin` is flashed. The bootloader, partition table, and NVS storage are untouched, so all saved settings survive.
+- **New install** (first-time setup or blank device): ESP Web Tools detects no valid firmware and additionally flashes `new_install_parts` (bootloader, partitions, boot_app0, tinyuf2) before flashing `firmware.bin`.
+
+If you need to do a full re-flash of a device that already has firmware (e.g. to recover from a corrupted partition table), use the PlatformIO method described in `Documentation/flash-firmware/README.md`.
 
 ## Browser requirements
 

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.4.5 - 2026-04-16
+
+- Distance display below 2m now shows two decimal places (e.g. `1.85m`) instead of one.
+- Add display brightness control to Setup > UI Settings:
+  - **Brightness mode**: Auto (scales with ambient light from BH1750) or Manual.
+  - **Brightness top** (Auto): sets the maximum brightness ceiling from 50% to 100% in 10% steps.
+  - **Brightness level** (Manual): sets a fixed brightness from 5% to 100% in 5% steps.
+  - Both settings persisted to NVS and survive reboots.
+- Add **Horizon line** toggle to Setup > UI Settings (On/Off), persisted to NVS.
+
 ## 10.4.0 - 2026-04-15
 
 - Add visual focus reticle offset adjustment (Setup > UI Settings > Focus reticle).

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.4.0
+**Version**: 10.4.5
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 
@@ -127,7 +127,7 @@ Firmware/
 - Confidence-aware temporal smoothing (accept, blend, or hold previous reading)
 - In Main mode, LiDAR idle standby timeout is user-configurable (`Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m`; default `1m`)
 - While LiDAR is in idle standby, the distance readout shows `Zzz`
-- Distance display uses `cm` below `1m`, with `<15cm` near clamp, `Inf.` above `10.5m` or when far-range signal is lost
+- Distance display uses `cm` below `1m`, two decimal places from `1m` to below `2m` (e.g. `1.85m`), one decimal place at `2m` and above, `<15cm` near clamp, `Inf.` above `10.5m` or when far-range signal is lost
 - Range: 5cm to 18m
 
 #### Light Metering
@@ -187,6 +187,12 @@ pio test -e native_core_tests
 - `DEFAULT_SLEEP_TIMEOUT_MODE` / `SLEEP_TIMEOUT_MODE_*`: Auto-sleep options (`Off`, `15s`, `30sec`, `1m`, `1m30s`, `2m`; default `1m30s`)
 - `DEFAULT_LIDAR_IDLE_TIMEOUT_MODE`: Awake-main LiDAR standby timeout default (`1m`)
 - `DEFAULT_RETICLE_OFFSET_X` / `DEFAULT_RETICLE_OFFSET_Y`: Reticle position offsets (default `-5`, `0`; range `-20` to `+20` px)
+- `DEFAULT_BRIGHTNESS_AUTO` / `DEFAULT_BRIGHTNESS_MANUAL_PCT` / `DEFAULT_BRIGHTNESS_AUTO_TOP_PCT`: Display brightness defaults (Auto mode on; manual level `100%`; auto top `100%`)
+- `BRIGHTNESS_MANUAL_MIN_PCT` / `BRIGHTNESS_MANUAL_STEP_PCT`: Manual brightness range (`5%`–`100%` in `5%` steps)
+- `BRIGHTNESS_AUTO_TOP_MIN_PCT` / `BRIGHTNESS_AUTO_TOP_STEP_PCT`: Auto top brightness range (`50%`–`100%` in `10%` steps)
+- `BRIGHTNESS_AUTO_LUX_MAX`: Lux ceiling for auto brightness scaling (`500 lux`)
+- `DEFAULT_SHOW_HORIZON_LINE`: Horizon line visibility default (`true`)
+- `DISTANCE_NEAR_THRESHOLD_CM` / `DISTANCE_DECIMAL_PLACES_NEAR`: Two-decimal-place threshold and precision (`200cm`, `2` places)
 - `SMOOTHING_WINDOW_SIZE`: Filter window (13 samples)
 - `LENS_INF_THRESHOLD`: Infinity focus threshold
 - `LIDAR_LIBRARY_DISTANCE_SCALE`: LiDAR library distance scaling factor
@@ -213,6 +219,8 @@ The system saves:
 - Sleep timeout mode
 - LiDAR idle timeout mode
 - UI horizon trim offsets (landscape, portrait `P+`, portrait `P-`)
+- Horizon line visibility
+- Display brightness mode (Auto/Manual), auto top brightness, manual brightness level
 - Reticle offset X/Y
 - Light-meter EV/smoothing/readout settings
 - Lens calibration data

--- a/Firmware/include/cyclefuncs.h
+++ b/Firmware/include/cyclefuncs.h
@@ -25,6 +25,9 @@ void cycleLidarIdleTimeoutMode();
 void cycleLevelTrimLandscape();
 void cycleLevelTrimPortraitPos();
 void cycleLevelTrimPortraitNeg();
+void toggleHorizonLine();
+void cycleBrightnessMode();
+void cycleBrightnessValue();
 const char *getSleepTimeoutModeLabel(int timeout_mode);
 unsigned long getSleepTimeoutModeMs(int timeout_mode);
 // ---------------------

--- a/Firmware/include/globals.h
+++ b/Firmware/include/globals.h
@@ -46,6 +46,10 @@ extern int level_trim_portrait_pos_deci_deg;
 extern int level_trim_portrait_neg_deci_deg;
 extern int reticle_offset_x;
 extern int reticle_offset_y;
+extern bool brightness_auto;
+extern int brightness_manual_pct;
+extern int brightness_auto_top_pct;
+extern bool show_horizon_line;
 
 // Filter algorithm
 extern int samples[SMOOTHING_WINDOW_SIZE];

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.4.0"                  // Version shown in UI and release metadata.
+#define FWVERSION "10.4.5"                  // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------
@@ -78,8 +78,20 @@ const int SHARED_I2C_FREQUENCY_HZ  = 400000;           // Standard I2C speed res
 const int DISPLAY_COMMAND_FLIP = 0xC8;                 // SH1107 vertical flip command.
 const uint8_t OLED_CMD_DISPLAY_OFF = 0xAE;             // SH1107 command to blank the display.
 const uint8_t OLED_CMD_DISPLAY_ON  = 0xAF;             // SH1107 command to enable the display.
+const uint8_t OLED_CMD_SET_CONTRAST = 0x81;            // SH1107 set-contrast command byte.
 const unsigned long FADE_STEP_INTERVAL_MS = 25;        // Delay between non-blocking fade steps.
 const int FADE_STEP_DECREMENT = 0x20;                  // Contrast decrement per fade step.
+const unsigned long BRIGHTNESS_UPDATE_INTERVAL_MS = 1000; // How often auto-brightness re-evaluates.
+const int BRIGHTNESS_MANUAL_MIN_PCT = 5;               // Minimum manual brightness (%).
+const int BRIGHTNESS_MANUAL_STEP_PCT = 5;              // Manual brightness step size (%).
+const int BRIGHTNESS_AUTO_TOP_MIN_PCT = 50;            // Minimum settable auto top brightness (%).
+const int BRIGHTNESS_AUTO_TOP_STEP_PCT = 10;           // Auto top brightness step size (%).
+const int BRIGHTNESS_PCT_MAX = 100;                    // Maximum brightness (%).
+const int BRIGHTNESS_AUTO_MIN_PCT = 10;                // Auto floor brightness (% of top).
+const float BRIGHTNESS_AUTO_LUX_MAX = 500.0f;          // Lux ceiling for auto scaling.
+const bool DEFAULT_BRIGHTNESS_AUTO = true;             // Default brightness mode (true = auto).
+const int DEFAULT_BRIGHTNESS_MANUAL_PCT = 100;         // Default manual brightness level (%).
+const int DEFAULT_BRIGHTNESS_AUTO_TOP_PCT = 100;       // Default auto top brightness (%).
 
 // ---------------------------------------------------------------------------
 // Lens ADC filtering, snap logic, and focus-ring rendering
@@ -214,7 +226,9 @@ const int LIDAR_DISPLAY_INF_THRESHOLD_CM = 1050; // Display "Inf." above this th
 // ---------------------------------------------------------------------------
 const int BATTERY_PERCENT_MAX = 100;          // Clamp battery percentage upper bound.
 const int BATTERY_PERCENT_LOW_THRESHOLD = 10; // Low-battery threshold used by external UI layout.
-const int DISTANCE_DECIMAL_PLACES = 1;        // Decimal precision for meter display text.
+const int DISTANCE_DECIMAL_PLACES = 1;        // Decimal precision for meter display text (>= 2m).
+const int DISTANCE_DECIMAL_PLACES_NEAR = 2;   // Decimal precision below DISTANCE_NEAR_THRESHOLD_CM.
+const int DISTANCE_NEAR_THRESHOLD_CM = 200;   // Show extra decimal below this distance (2m).
 
 // ---------------------------------------------------------------------------
 // Light meter and shutter text formatting
@@ -365,6 +379,9 @@ enum ConfigUiStep
   CONFIG_UI_STEP_HORIZON_LANDSCAPE = 0,  // Landscape horizon trim.
   CONFIG_UI_STEP_HORIZON_PORTRAIT_POS,   // Portrait + horizon trim.
   CONFIG_UI_STEP_HORIZON_PORTRAIT_NEG,   // Portrait - horizon trim.
+  CONFIG_UI_STEP_HORIZON_ENABLE,         // Horizon line on/off toggle.
+  CONFIG_UI_STEP_BRIGHTNESS_MODE,        // Display brightness mode (Auto/Manual).
+  CONFIG_UI_STEP_BRIGHTNESS_VALUE,       // Display brightness level.
   CONFIG_UI_STEP_SLEEP_TIMEOUT,          // Sleep timeout selector.
   CONFIG_UI_STEP_LIDAR_IDLE_TIMEOUT,     // LiDAR idle-timeout selector.
   CONFIG_UI_STEP_RETICLE_ADJUST,         // Enter reticle offset adjustment.
@@ -392,6 +409,7 @@ const float LEVEL_PORTRAIT_ENTER_RAD = 1.00f; // Enter portrait mode threshold.
 const float LEVEL_PORTRAIT_EXIT_RAD = 0.75f;  // Exit portrait mode threshold.
 const int LEVEL_LINE_MARGIN_PX = 10;        // Horizon line horizontal margin.
 const int LEVEL_VERTICAL_LINE_LENGTH = 30;  // Center marker vertical line length.
+const bool DEFAULT_SHOW_HORIZON_LINE = true; // Default horizon line visibility.
 
 // ---------------------------------------------------------------------------
 // Main display layout coordinates

--- a/Firmware/src/cyclefuncs.cpp
+++ b/Firmware/src/cyclefuncs.cpp
@@ -267,6 +267,39 @@ void cycleLevelTrimPortraitNeg()
   savePrefs(false, PREFS_DIRTY_SETTINGS);
 }
 
+void toggleHorizonLine()
+{
+  show_horizon_line = !show_horizon_line;
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
+}
+
+void cycleBrightnessMode()
+{
+  brightness_auto = !brightness_auto;
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
+}
+
+void cycleBrightnessValue()
+{
+  if (brightness_auto)
+  {
+    brightness_auto_top_pct = cycleValueWrapping(
+        brightness_auto_top_pct,
+        BRIGHTNESS_AUTO_TOP_STEP_PCT,
+        BRIGHTNESS_AUTO_TOP_MIN_PCT,
+        BRIGHTNESS_PCT_MAX);
+  }
+  else
+  {
+    brightness_manual_pct = cycleValueWrapping(
+        brightness_manual_pct,
+        BRIGHTNESS_MANUAL_STEP_PCT,
+        BRIGHTNESS_MANUAL_MIN_PCT,
+        BRIGHTNESS_PCT_MAX);
+  }
+  savePrefs(false, PREFS_DIRTY_SETTINGS);
+}
+
 void cycleSleepTimeoutMode()
 {
   sleep_timeout_mode = cycleValueWrapping(sleep_timeout_mode, 1, SLEEP_TIMEOUT_MODE_MIN, SLEEP_TIMEOUT_MODE_MAX);

--- a/Firmware/src/globals.cpp
+++ b/Firmware/src/globals.cpp
@@ -28,6 +28,10 @@ int level_trim_portrait_pos_deci_deg = DEFAULT_LEVEL_TRIM_PORTRAIT_POS_DECI_DEG;
 int level_trim_portrait_neg_deci_deg = DEFAULT_LEVEL_TRIM_PORTRAIT_NEG_DECI_DEG;
 int reticle_offset_x = DEFAULT_RETICLE_OFFSET_X;
 int reticle_offset_y = DEFAULT_RETICLE_OFFSET_Y;
+bool brightness_auto = DEFAULT_BRIGHTNESS_AUTO;
+int brightness_manual_pct = DEFAULT_BRIGHTNESS_MANUAL_PCT;
+int brightness_auto_top_pct = DEFAULT_BRIGHTNESS_AUTO_TOP_PCT;
+bool show_horizon_line = DEFAULT_SHOW_HORIZON_LINE;
 
 // Filter algorithm
 int samples[SMOOTHING_WINDOW_SIZE];

--- a/Firmware/src/helpers.cpp
+++ b/Firmware/src/helpers.cpp
@@ -72,6 +72,10 @@ void writeSettingsPrefs()
   prefs.putInt("lvl_trim_pn10", level_trim_portrait_neg_deci_deg);
   prefs.putInt("reticle_x", reticle_offset_x);
   prefs.putInt("reticle_y", reticle_offset_y);
+  prefs.putBool("bright_auto", brightness_auto);
+  prefs.putInt("bright_man_pct", brightness_manual_pct);
+  prefs.putInt("bright_top_pct", brightness_auto_top_pct);
+  prefs.putBool("show_horizon", show_horizon_line);
 }
 
 void writeFilmPrefs()
@@ -202,6 +206,8 @@ void clampLoadedState()
 
   reticle_offset_x = constrain(reticle_offset_x, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
   reticle_offset_y = constrain(reticle_offset_y, RETICLE_OFFSET_MIN, RETICLE_OFFSET_MAX);
+  brightness_manual_pct = constrain(brightness_manual_pct, BRIGHTNESS_MANUAL_MIN_PCT, BRIGHTNESS_PCT_MAX);
+  brightness_auto_top_pct = constrain(brightness_auto_top_pct, BRIGHTNESS_AUTO_TOP_MIN_PCT, BRIGHTNESS_PCT_MAX);
 
   frame_one_offset = constrain(frame_one_offset, FRAME_TUNING_MIN, FRAME_TUNING_MAX);
   frame_spacing_offset = constrain(frame_spacing_offset, FRAME_TUNING_MIN, FRAME_TUNING_MAX);
@@ -307,6 +313,10 @@ void loadPrefs()
   level_trim_portrait_neg_deci_deg = prefs.getInt("lvl_trim_pn10", legacy_trim_pn * 10);
   reticle_offset_x = prefs.getInt("reticle_x", DEFAULT_RETICLE_OFFSET_X);
   reticle_offset_y = prefs.getInt("reticle_y", DEFAULT_RETICLE_OFFSET_Y);
+  brightness_auto = prefs.getBool("bright_auto", DEFAULT_BRIGHTNESS_AUTO);
+  brightness_manual_pct = prefs.getInt("bright_man_pct", DEFAULT_BRIGHTNESS_MANUAL_PCT);
+  brightness_auto_top_pct = prefs.getInt("bright_top_pct", DEFAULT_BRIGHTNESS_AUTO_TOP_PCT);
+  show_horizon_line = prefs.getBool("show_horizon", DEFAULT_SHOW_HORIZON_LINE);
   film_counter = prefs.getInt("film_counter", 0);
   encoder_value = prefs.getInt("encoder_value", 0);
   prev_encoder_value = prefs.getInt("prev_encoder_value", 0);

--- a/Firmware/src/inputs.cpp
+++ b/Firmware/src/inputs.cpp
@@ -391,6 +391,15 @@ void handleRightButtonShortPress()
     else if (config_step == CONFIG_UI_STEP_HORIZON_PORTRAIT_NEG) {
       cycleLevelTrimPortraitNeg();
     }
+    else if (config_step == CONFIG_UI_STEP_HORIZON_ENABLE) {
+      toggleHorizonLine();
+    }
+    else if (config_step == CONFIG_UI_STEP_BRIGHTNESS_MODE) {
+      cycleBrightnessMode();
+    }
+    else if (config_step == CONFIG_UI_STEP_BRIGHTNESS_VALUE) {
+      cycleBrightnessValue();
+    }
     else if (config_step == CONFIG_UI_STEP_SLEEP_TIMEOUT) {
       cycleSleepTimeoutMode();
     }

--- a/Firmware/src/interface.cpp
+++ b/Firmware/src/interface.cpp
@@ -718,7 +718,10 @@ void drawMainUI()
   MainFramelineLayout framelineLayout = buildMainFramelineLayout();
   drawMainFrameline(framelineLayout);
   drawReticleAndFocusRing(framelineLayout);
-  drawLevelIndicator(framelineLayout.reticleCenterX, framelineLayout.reticleCenterY);
+  if (show_horizon_line)
+  {
+    drawLevelIndicator(framelineLayout.reticleCenterX, framelineLayout.reticleCenterY);
+  }
 
   display.display();
 }
@@ -873,6 +876,28 @@ void drawUiConfigUI()
   u8g2.print(F(" Horizon Portrait-:"));
   printSignedDeciDegrees(level_trim_portrait_neg_deci_deg);
   u8g2.print(F("deg "));
+
+  selectConfigMenuRow(CONFIG_UI_STEP_HORIZON_ENABLE, config_step == CONFIG_UI_STEP_HORIZON_ENABLE);
+  u8g2.print(F(" Horizon line: "));
+  u8g2.print(show_horizon_line ? F("On ") : F("Off"));
+
+  selectConfigMenuRow(CONFIG_UI_STEP_BRIGHTNESS_MODE, config_step == CONFIG_UI_STEP_BRIGHTNESS_MODE);
+  u8g2.print(F(" Bright mode: "));
+  u8g2.print(brightness_auto ? F("Auto  ") : F("Manual"));
+
+  selectConfigMenuRow(CONFIG_UI_STEP_BRIGHTNESS_VALUE, config_step == CONFIG_UI_STEP_BRIGHTNESS_VALUE);
+  if (brightness_auto)
+  {
+    u8g2.print(F(" Bright top: "));
+    u8g2.print(brightness_auto_top_pct);
+    u8g2.print(F("% "));
+  }
+  else
+  {
+    u8g2.print(F(" Bright level: "));
+    u8g2.print(brightness_manual_pct);
+    u8g2.print(F("% "));
+  }
 
   selectConfigMenuRow(CONFIG_UI_STEP_SLEEP_TIMEOUT, config_step == CONFIG_UI_STEP_SLEEP_TIMEOUT);
   u8g2.print(F(" Sleep timeout: "));

--- a/Firmware/src/lidar_logic.cpp
+++ b/Firmware/src/lidar_logic.cpp
@@ -527,9 +527,12 @@ void formatDistanceDisplay(int corrected_cm, char *buffer, size_t bufferSize)
     snprintf(buffer, bufferSize, "%dcm", corrected_cm);
     return;
   }
+  int decimalPlaces = (corrected_cm < DISTANCE_NEAR_THRESHOLD_CM)
+                          ? DISTANCE_DECIMAL_PLACES_NEAR
+                          : DISTANCE_DECIMAL_PLACES;
   snprintf(buffer,
            bufferSize,
            "%.*fm",
-           DISTANCE_DECIMAL_PLACES,
+           decimalPlaces,
            static_cast<float>(corrected_cm) / static_cast<float>(CM_PER_METER));
 }

--- a/Firmware/src/loop_runtime.cpp
+++ b/Firmware/src/loop_runtime.cpp
@@ -32,6 +32,7 @@ struct LoopScheduler
   unsigned long lastBatteryMs = 0;
   unsigned long lastUiMs = 0;
   unsigned long lastPrefsFlushMs = 0;
+  unsigned long lastBrightnessMs = 0;
 };
 
 struct UiRenderCache
@@ -128,6 +129,7 @@ uint32_t buildMainUiSignature()
   hash = hashBool(hash, parallaxEnabled);
   hash = hashInt(hash, reticle_offset_x);
   hash = hashInt(hash, reticle_offset_y);
+  hash = hashBool(hash, show_horizon_line);
   return hash;
 }
 
@@ -158,6 +160,10 @@ uint32_t buildMenuUiSignature()
   hash = hashInt(hash, reticle_offset_x);
   hash = hashInt(hash, reticle_offset_y);
   hash = hashInt(hash, reticle_adjust_step);
+  hash = hashBool(hash, brightness_auto);
+  hash = hashInt(hash, brightness_manual_pct);
+  hash = hashInt(hash, brightness_auto_top_pct);
+  hash = hashBool(hash, show_horizon_line);
   hash = hashInt(hash, frame_one_offset);
   hash = hashInt(hash, frame_spacing_offset);
   hash = hashInt(hash, film_counter);
@@ -460,16 +466,39 @@ void stepFadeOutMainDisplay(unsigned long nowMs)
   }
 }
 
+uint8_t computeTargetBrightnessByte()
+{
+  if (brightness_auto)
+  {
+    float topFraction = static_cast<float>(brightness_auto_top_pct) / 100.0f;
+    float minFraction = static_cast<float>(BRIGHTNESS_AUTO_MIN_PCT) / 100.0f * topFraction;
+    uint8_t topByte = static_cast<uint8_t>(topFraction * 0xFF);
+    uint8_t minByte = static_cast<uint8_t>(minFraction * 0xFF);
+    float clampedLux = constrain(lux, 0.0f, BRIGHTNESS_AUTO_LUX_MAX);
+    float scaled = clampedLux / BRIGHTNESS_AUTO_LUX_MAX;
+    return static_cast<uint8_t>(minByte + scaled * (topByte - minByte));
+  }
+  return static_cast<uint8_t>(brightness_manual_pct * 0xFF / 100);
+}
+
+void applyDisplayBrightness()
+{
+  if (!mainDisplayReady || loopState.fade.active)
+  {
+    return;
+  }
+  display.oled_command(OLED_CMD_SET_CONTRAST);
+  display.oled_command(computeTargetBrightnessByte());
+}
+
 void restoreMainDisplayBrightness()
 {
   if (!mainDisplayReady)
   {
     return;
   }
-
-  // Restore default contrast after wake.
-  display.oled_command(0x81);
-  display.oled_command(0xFF);
+  display.oled_command(OLED_CMD_SET_CONTRAST);
+  display.oled_command(computeTargetBrightnessByte());
 }
 
 void beginSleepFade(unsigned long nowMs)
@@ -825,6 +854,10 @@ void runAwakeTasks(unsigned long nowMs)
   updateLightMeterTask(nowMs);
   updateBatteryTask(nowMs);
   updateUiTask(nowMs);
+  if (shouldRunTask(nowMs, loopState.scheduler.lastBrightnessMs, BRIGHTNESS_UPDATE_INTERVAL_MS))
+  {
+    applyDisplayBrightness();
+  }
 }
 
 void flushPrefsTask(unsigned long nowMs)


### PR DESCRIPTION
## Summary

- **Near-distance precision**: LiDAR distance display now shows two decimal places below 2m (e.g. `1.85m`), one decimal at 2m and above.
- **Display brightness control** (Setup > UI Settings):
  - *Bright mode*: Auto (scales with ambient lux from BH1750) or Manual.
  - *Bright top* (Auto): maximum brightness ceiling, 50%–100% in 10% steps.
  - *Bright level* (Manual): fixed brightness, 5%–100% in 5% steps.
  - Brightness re-evaluated every second while awake; both settings persisted to NVS.
- **Horizon line toggle** (Setup > UI Settings): On/Off, persisted to NVS.
- **Web updater preserves settings on upgrade**: manifest now uses `new_install_parts` so regular firmware updates only flash `firmware.bin`, leaving NVS untouched. Full infrastructure flash (bootloader, partitions, tinyuf2) only runs on first-time installs.

## Test plan

- [x] Flash via web updater — confirm saved settings (lens, ISO, reticle offsets, calibration) survive
- [x] Distance reads `1.85m` style between 1–2m; `2.5m` style at 2m+; `75cm` below 1m
- [x] Setup > UI Settings shows: Horizon line, Bright mode, Bright top/level — all in correct order before Sleep timeout
- [x] Horizon line On/Off — horizon line appears/disappears on main viewfinder immediately
- [x] Bright mode Auto: brightness visibly scales moving between dark and bright environments
- [x] Bright top: reducing ceiling in Auto mode visibly limits maximum brightness
- [x] Bright mode Manual: brightness fixed regardless of ambient light
- [x] Bright level: adjusting level in Manual mode takes effect immediately
- [x] All brightness and horizon settings survive reboot

