### PR TITLE
Docs: cover Linux and Windows in the build/flash guide

### DIFF
--- a/Documentation/flash-firmware/README.md
+++ b/Documentation/flash-firmware/README.md
@@ -1,15 +1,37 @@
-# Flashing the MRF2 Firmware (VS Code + PlatformIO)
+# Flashing the MRF2 Firmware
 
-This guide walks through building and flashing the firmware using VS Code with the PlatformIO IDE extension. It assumes you have the repo checked out and want to flash the `Firmware/` project.
+This guide walks through building and flashing the firmware on **macOS, Linux, and Windows**. It assumes you have the repo checked out and want to flash the `Firmware/` project.
 
-If you prefer browser-based flashing, use the GitHub Pages updater:
+Two paths are covered:
+
+- **VS Code + PlatformIO IDE** (recommended for most builders): sections 1 through 7.
+- **Command line (PlatformIO Core)**: the CLI section near the end.
+
+If you would rather not install anything, use the browser-based updater instead:
 `https://update.mrf2.com/`
 
-## Prerequisites
+The MRF2 board is an Adafruit Feather ESP32-S3. It uses the ESP32-S3's **native USB**, so there is **no CP210x/CH340 USB-to-serial chip and no vendor driver to install** on any operating system. The notes below cover the few things that do differ per OS: serial port permissions on Linux, COM-port behavior on Windows, and the bootloader recovery sequence.
+
+## Prerequisites (all platforms)
 - VS Code installed
 - PlatformIO IDE extension installed
-- USB-C data cable (charge-only cables will not work)
+- A **USB-C data cable** (charge-only cables will not enumerate a serial port)
 - MRF2 powered on
+
+### Per-platform setup notes
+
+#### macOS
+
+- No driver needed. The board appears as `/dev/tty.usbmodem*`.
+
+#### Windows (10/11)
+
+- No driver needed. Windows installs the built-in USB CDC (serial) driver automatically the first time you plug the board in; it appears as a `COMx` port in Device Manager under "Ports (COM & LPT)".
+- If the port never appears, see the Windows note in Troubleshooting.
+
+#### Linux
+
+- No driver needed, but your user must have permission to access the serial device, and `ModemManager` can interfere with uploads. Both are one-time fixes; see [Linux serial port access](#linux-serial-port-access) below before your first upload.
 
 ## 1) Install VS Code extensions
 1. Open VS Code.
@@ -31,8 +53,8 @@ If you prefer browser-based flashing, use the GitHub Pages updater:
 1. Switch on the MRF2 and connect it via USB-C.
 2. In the bottom bar, click the **Serial Port** selector and choose **Auto** or the correct port.
    - macOS examples: `/dev/tty.usbmodem*`
+   - Linux examples: `/dev/ttyACM0` (native USB) or `/dev/ttyUSB0`
    - Windows examples: `COM3`, `COM4`
-   - Linux examples: `/dev/ttyUSB0` or `/dev/ttyACM0`
 
 ## 5) Upload (flash)
 1. Click **Upload** (right-arrow icon) in the PlatformIO toolbar.
@@ -41,6 +63,7 @@ If you prefer browser-based flashing, use the GitHub Pages updater:
 If upload fails:
 - Put the ESP32-S3 into bootloader mode: **hold BOOT**, tap **RESET**, then release BOOT and retry upload.
 - Try a different USB-C cable or USB port.
+- On Linux, confirm serial permissions (see below). On Windows, confirm the COM port appears in Device Manager.
 
 ## 6) Verify on device
 1. Disconnect USB.
@@ -51,9 +74,104 @@ If upload fails:
 1. Click **Monitor** (plug icon) in the PlatformIO toolbar.
 2. Use **115200 baud** (matches `SERIAL_BAUD_RATE` in `Firmware/include/mrfconstants.h`).
 
-For command-line build/upload/monitor, see `Firmware/README.md`.
+---
+
+## Linux serial port access
+
+On most distributions the serial device is owned by the `dialout` group (Debian/Ubuntu) or `uucp` group (Arch/Fedora). If you are not a member, uploads and the monitor fail with "permission denied".
+
+1. Find your distro's serial group and add yourself to it:
+   ```bash
+   # Debian / Ubuntu / Raspberry Pi OS
+   sudo usermod -aG dialout "$USER"
+
+   # Arch / Fedora / openSUSE
+   sudo usermod -aG uucp "$USER"
+   ```
+2. **Log out and back in** (or reboot) for the group change to take effect.
+3. Verify the device shows up after plugging in the board:
+   ```bash
+   ls -l /dev/ttyACM* /dev/ttyUSB*
+   ```
+
+**ModemManager grabbing the port:** on desktop Linux, `ModemManager` may probe the board the moment it enumerates and cause upload timeouts. If uploads intermittently fail right after plugging in, either wait a few seconds before uploading, or stop ModemManager:
+```bash
+sudo systemctl stop ModemManager     # for this session
+sudo systemctl disable ModemManager  # permanently, if you do not use cellular modems
+```
+
+PlatformIO can also install the official udev rules for you if the port is not detected. See `https://docs.platformio.org/en/latest/core/installation/udev-rules.html`.
+
+---
+
+## Command line (PlatformIO Core)
+
+Use this if you prefer the terminal or are flashing on a headless machine. All commands assume your working directory is `Firmware/` (or pass `-d Firmware` from the repo root).
+
+### Install PlatformIO Core
+
+PlatformIO Core needs Python 3.6+.
+
+**macOS / Linux**
+```bash
+python3 -m pip install --user platformio
+# then make sure ~/.local/bin is on your PATH, e.g. for bash/zsh:
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+**Windows (PowerShell)**
+```powershell
+py -m pip install --user platformio
+# pio.exe lands in %APPDATA%\Python\PythonXY\Scripts; add it to PATH if `pio` is not found
+```
+
+Confirm the install:
+```bash
+pio --version
+```
+
+(Alternatively, install the **PlatformIO IDE** extension in VS Code and use its bundled `pio` from the PlatformIO Core CLI terminal, with no separate install needed.)
+
+### Build, flash, monitor
+
+```bash
+# Build the firmware for the ESP32-S3
+pio run -e adafruit_feather_esp32s3
+
+# Flash a connected board (auto-detects the port)
+pio run -e adafruit_feather_esp32s3 --target upload
+
+# Open the serial monitor (115200 baud)
+pio run -e adafruit_feather_esp32s3 --target monitor
+```
+
+To target a specific port, append `--upload-port`:
+```bash
+# Linux
+pio run -e adafruit_feather_esp32s3 --target upload --upload-port /dev/ttyACM0
+# Windows
+pio run -e adafruit_feather_esp32s3 --target upload --upload-port COM4
+# macOS
+pio run -e adafruit_feather_esp32s3 --target upload --upload-port /dev/tty.usbmodem1101
+```
+
+List detected ports with `pio device list`.
+
+### Host-side tests (no hardware required)
+
+These run on your computer and do not touch the board, so they work the same on all three platforms:
+```bash
+pio test -e native_core_tests
+```
+
+---
 
 ## Troubleshooting
-- **No serial port listed**: try a different cable/port or check USB permissions (Linux).
+- **No serial port listed (all platforms)**: try a different cable (must be a data cable) or a different USB port.
+- **No COM port on Windows**: open Device Manager and watch "Ports (COM & LPT)" while plugging the board in. If it appears under "Other devices" with a warning, unplug, wait, and replug; if it still fails, try another USB port or cable. No vendor driver is required for this board.
+- **Permission denied on Linux**: add your user to the serial group and re-login (see [Linux serial port access](#linux-serial-port-access)).
+- **Upload starts but fails to connect**: hold **BOOT**, tap **RESET**, release **BOOT**, then retry the upload.
 - **Build errors on first run**: let PlatformIO finish downloading toolchains, then retry.
-- **Upload starts but fails to connect**: use BOOT/RESET sequence and retry.
+- **Upload times out intermittently on Linux**: stop `ModemManager` (see above).
+
+For the firmware architecture and configuration reference, see `Firmware/README.md`.

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -157,7 +157,7 @@ Firmware/
 
 ## Building and Flashing
 
-For the step-by-step VS Code + PlatformIO workflow, see `Documentation/flash-firmware/README.md`.
+For the step-by-step build and flash workflow on macOS, Linux, and Windows (VS Code or CLI), see `Documentation/flash-firmware/README.md`.
 
 ### CLI Build Commands
 ```bash

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can [support me on Patreon](https://patreon.com/IDENTIDEMdesign), or just sh
 
 ## 📚 Documentation Index
 
-- `Documentation/flash-firmware/README.md` – Flashing the firmware with VS Code + PlatformIO
+- `Documentation/flash-firmware/README.md` – Building and flashing the firmware on macOS, Linux, and Windows (VS Code or CLI)
 - `Documentation/web-updater/README.md` – GitHub Pages browser updater architecture and deployment
 - `Documentation/user-manual/USER_MANUAL.md` – On-device UI and calibration user manual
 - `Firmware/README.md` – Firmware architecture, configuration, and CLI build commands
@@ -40,7 +40,7 @@ You can [support me on Patreon](https://patreon.com/IDENTIDEMdesign), or just sh
 1. **Order PCBs**: Use the Gerbers in `PCBs/Main PCB/Gerber` and `PCBs/Breakout/Gerber`. The `.gbrjob` files can be uploaded directly to most fabs.
 2. **Assemble electronics**: Populate the main and breakout boards with the BoM below (through-hole and SMT mix), attach the Feather ESP32-S3, and wire the displays/sensors via STEMMA QT/Qwiic where applicable.
 3. **Print the body**: Slice/print the 3MF models (see `3MF/` and any profiles in `OrcaSlicer/`). Fit tolerances may depend on your printer and material.
-4. **Load firmware**: Use `Documentation/flash-firmware/README.md` (VS Code) or `Firmware/README.md` (CLI), then run first-time calibration.
+4. **Load firmware**: Follow `Documentation/flash-firmware/README.md` (macOS/Linux/Windows, VS Code or CLI), then run first-time calibration.
 5. **Integrate**: Install the PCBs and displays into the printed parts, route wiring, and verify focus/meters on the bench before loading film.
 
 ## 🧱 Bill of Materials


### PR DESCRIPTION
The flash guide was written around the macOS VS Code path. Extend it to all three desktop platforms and add a command-line route.

- State that the Feather ESP32-S3 uses native USB, so no CP210x/CH340 driver is needed on any OS (Windows installs the CDC driver itself).
- Add a Linux serial-access section: dialout/uucp group membership and the ModemManager upload-timeout fix.
- Add a PlatformIO Core CLI section with per-OS install and a --upload-port example for each platform.
- Update the guide pointers in the root and firmware READMEs to match the wider scope.