### PR TITLE
Film-advance boot animation on the external display (v10.6.1)

### DIFF
--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -55,7 +55,7 @@ If this is your first time using the camera, this sequence keeps things simple a
 
 ## Quick start (after initial setup)
 
-1. Power on the camera. The main display shows an "Initialising..." progress bar with a label naming each peripheral group as it starts up, the external display shows a short boot screen, and then the main UI appears.
+1. Power on the camera. The main display shows an "Initialising..." progress bar with a label naming each peripheral group as it starts up, the external display plays a short film-advance animation that carries the firmware version into view, and then the main UI appears.
 2. Check the **main screen** for ISO, aperture, shutter speed, LiDAR distance, LiDAR quality blocks, and lens distance.
 3. Long-press **Right (R)** for 3 seconds to enter **Setup** and make changes.
 4. Use the **advance lever** to move the film; the external display shows the frame counter and progress bar.

--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.6.0
+**Firmware version:** 10.6.1
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.0</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.1</text>
 </svg>

--- a/Documentation/user-manual/images/health-ui.svg
+++ b/Documentation/user-manual/images/health-ui.svg
@@ -2,7 +2,7 @@
   <rect x="0" y="0" width="128" height="128" fill="#000000" stroke="#ffffff" stroke-width="1"/>
   <text x="3" y="15" font-family="monospace" font-size="10" fill="#ffffff">System Health</text>
 
-  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.0</text>
+  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.1</text>
   <text x="4" y="40" font-family="monospace" font-size="6" fill="#ffffff">Prefs: v2 OK</text>
   <text x="4" y="50" font-family="monospace" font-size="6" fill="#ffffff">LiDAR: InitErr Off err:0</text>
   <text x="4" y="60" font-family="monospace" font-size="6" fill="#ffffff">Recoveries: 0</text>

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.6.1 - 2026-07-13
+
+### External display boot animation
+
+- Replaced the static `MRF X.Y.Z` boot splash on the external OLED with a film-advance animation: sprocket perforations tick along the top and bottom edges while the version rides in from the right and settles centred, like loading a fresh roll. The per-frame geometry lives in a new host-tested `boot_animation_logic` module; the draw loop stays thin. Boot timing is unchanged (~1 s). Verify boot timing and legibility on device.
+
 ## 10.6.0 - 2026-07-13
 
 ### Whole-codebase review fixes (safety, persistence, input, rendering, lifecycle)

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.6.0
+**Version**: 10.6.1
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 

--- a/Firmware/include/boot_animation_logic.h
+++ b/Firmware/include/boot_animation_logic.h
@@ -1,0 +1,19 @@
+#ifndef BOOT_ANIMATION_LOGIC_H
+#define BOOT_ANIMATION_LOGIC_H
+
+// Pure geometry for the external-display film-advance boot animation.
+// No Arduino/Adafruit types so it can be unit-tested on the host.
+
+// Eased left-edge x (px) of the version text for a given animation frame.
+// The film feeds in from the right: frame 0 starts fully off-screen
+// (x == displayWidth) and the sequence eases out to the centered x on the
+// final frame (frame == totalFrames - 1). Monotonically non-increasing.
+// frame is clamped to [0, totalFrames - 1]; totalFrames <= 1 returns centered.
+int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth);
+
+// Wrapped x-offset (0..spacingPx-1) of the sprocket perforations for a frame,
+// advancing by stepPx each frame so the film reads as moving left.
+// spacingPx <= 0 returns 0.
+int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx);
+
+#endif // BOOT_ANIMATION_LOGIC_H

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.6.0"                   // Version shown in UI and release metadata.
+#define FWVERSION "10.6.1"                   // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -66,7 +66,13 @@ const int NEOPIXEL_OFF_B = 0;                  // LED-off B channel.
 
 const unsigned long DISPLAY_INIT_DELAY_MS = 1000;      // Main display power-up settle delay.
 const unsigned long DISPLAY_EXT_INIT_DELAY_MS = 500;   // External display settle delay.
-const unsigned long DISPLAY_BOOT_SCREEN_MS = 1000;     // Boot splash hold time.
+const unsigned long DISPLAY_BOOT_SCREEN_MS = 400;      // Post-landing hold after the film settles.
+const int DISPLAY_BOOT_ANIM_FRAMES = 16;               // Number of animated film-advance frames.
+const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 40;   // Delay per animation frame (16*40 = 640 ms).
+const int DISPLAY_BOOT_SPROCKET_SPACING = 12;          // Px between sprocket-hole centres.
+const int DISPLAY_BOOT_SPROCKET_STEP = 3;              // Px the perforations shift per frame.
+const int DISPLAY_BOOT_SPROCKET_W = 6;                 // Sprocket-hole width in px.
+const int DISPLAY_BOOT_SPROCKET_H = 4;                 // Sprocket-hole height (top and bottom bands).
 const unsigned long LIDAR_SERIAL_STARTUP_DELAY_MS = 20; // LiDAR serial warm-up delay.
 const uint8_t LIGHTMETER_I2C_ADDR = 0x23;              // BH1750 I2C address.
 const uint8_t LIGHTMETER_CMD_POWER_DOWN = 0x00;        // BH1750 power-down command.

--- a/Firmware/src/boot_animation_logic.cpp
+++ b/Firmware/src/boot_animation_logic.cpp
@@ -1,0 +1,43 @@
+#include "boot_animation_logic.h"
+
+int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth)
+{
+  const int centered = (displayWidth - textWidth) / 2;
+  if (totalFrames <= 1)
+  {
+    return centered;
+  }
+  if (frame < 0)
+  {
+    frame = 0;
+  }
+  if (frame > totalFrames - 1)
+  {
+    frame = totalFrames - 1;
+  }
+
+  const long last = totalFrames - 1;
+  const int start = displayWidth;            // fully off the right edge
+  const long span = (long)(centered - start); // negative: text moves left
+
+  // Ease-out: eased = 1 - (1 - p)^2, with p = frame / last.
+  // easedNumerator / (last*last) == eased, kept in integer math.
+  const long remaining = last - frame;
+  const long easedNumerator = last * last - remaining * remaining;
+
+  return start + (int)(span * easedNumerator / (last * last));
+}
+
+int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx)
+{
+  if (spacingPx <= 0)
+  {
+    return 0;
+  }
+  long off = ((long)frame * stepPx) % spacingPx;
+  if (off < 0)
+  {
+    off += spacingPx;
+  }
+  return (int)off;
+}

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -13,6 +13,7 @@
 #include "helpers.h"
 #include "loop_runtime.h"
 #include "mrfconstants.h"
+#include "boot_animation_logic.h"
 #include "setfuncs.h"
 
 namespace
@@ -149,7 +150,7 @@ void showBootScreenOnExternalDisplay()
   snprintf(bootText, sizeof(bootText), "MRF %s", FWVERSION);
 
   // Pick the largest text size (up to the preferred one) that fits the display
-  // width, so a longer version string (e.g. 10.4.10) can't wrap on the narrow
+  // width, so a longer version string (e.g. 10.6.10) can't wrap on the narrow
   // external screen.
   int16_t bootTextX1 = 0;
   int16_t bootTextY1 = 0;
@@ -165,12 +166,35 @@ void showBootScreenOnExternalDisplay()
     }
   }
 
-  int16_t bootCursorX = ((display_ext.width() - static_cast<int16_t>(bootTextWidth)) / 2) - bootTextX1;
-  int16_t bootCursorY = ((display_ext.height() - static_cast<int16_t>(bootTextHeight)) / 2) - bootTextY1;
-  display_ext.setCursor(bootCursorX, bootCursorY);
-  display_ext.print(bootText);
-  display_ext.display();
+  const int16_t bootCursorY =
+      ((display_ext.height() - static_cast<int16_t>(bootTextHeight)) / 2) - bootTextY1;
 
+  // Film-advance animation: perforations tick left along the top and bottom
+  // edges while the version rides in from the right and eases to centre.
+  for (int frame = 0; frame < DISPLAY_BOOT_ANIM_FRAMES; frame++)
+  {
+    display_ext.clearDisplay();
+
+    const int sprocketOffset =
+        bootSprocketOffsetForFrame(frame, DISPLAY_BOOT_SPROCKET_STEP, DISPLAY_BOOT_SPROCKET_SPACING);
+    for (int x = sprocketOffset - DISPLAY_BOOT_SPROCKET_SPACING; x < display_ext.width();
+         x += DISPLAY_BOOT_SPROCKET_SPACING)
+    {
+      display_ext.fillRect(x, 0, DISPLAY_BOOT_SPROCKET_W, DISPLAY_BOOT_SPROCKET_H, SSD1306_WHITE);
+      display_ext.fillRect(x, display_ext.height() - DISPLAY_BOOT_SPROCKET_H,
+                           DISPLAY_BOOT_SPROCKET_W, DISPLAY_BOOT_SPROCKET_H, SSD1306_WHITE);
+    }
+
+    const int textX = bootTextXForFrame(frame, DISPLAY_BOOT_ANIM_FRAMES,
+                                        display_ext.width(), static_cast<int>(bootTextWidth));
+    display_ext.setCursor(static_cast<int16_t>(textX) - bootTextX1, bootCursorY);
+    display_ext.print(bootText);
+
+    display_ext.display();
+    delay(DISPLAY_BOOT_ANIM_FRAME_MS);
+  }
+
+  // Hold the settled frame, then clear and hand the panel to u8g2_ext as before.
   delay(DISPLAY_BOOT_SCREEN_MS);
 
   u8g2_ext.begin(display_ext);

--- a/Firmware/test/test_core_logic_regression/test_main.cpp
+++ b/Firmware/test/test_core_logic_regression/test_main.cpp
@@ -7,6 +7,7 @@
 #include "formats.h"
 #include "formatting_logic.h"
 #include "frameline_layout_logic.h"
+#include "boot_animation_logic.h"
 #include "calibration_logic.h"
 #include "lens_logic.h"
 #include "lens_spike_logic.h"
@@ -18,6 +19,7 @@
 #include "ui_signature_logic.h"
 
 // Limit the test scope to the core logic modules only.
+#include "../../src/boot_animation_logic.cpp"
 #include "../../src/calibration_logic.cpp"
 #include "../../src/film_counter_logic.cpp"
 #include "../../src/formats.cpp"
@@ -1540,6 +1542,58 @@ void test_ui_signature_menu_changes_when_focus_or_distance_offset_changes()
   TEST_ASSERT_NOT_EQUAL(baseline, buildMenuUiSignature(mutated));
 }
 
+void test_boot_text_starts_offscreen_right()
+{
+  // Frame 0: the version text begins fully off the right edge of the display.
+  TEST_ASSERT_TRUE(bootTextXForFrame(0, 16, 128, 120) >= 128);
+}
+
+void test_boot_text_lands_centered_on_final_frame()
+{
+  const int totalFrames = 16;
+  const int displayWidth = 128;
+  const int textWidth = 120;
+  int expectedCentered = (displayWidth - textWidth) / 2; // 4
+  TEST_ASSERT_EQUAL_INT(expectedCentered,
+                        bootTextXForFrame(totalFrames - 1, totalFrames, displayWidth, textWidth));
+}
+
+void test_boot_text_is_monotonically_non_increasing()
+{
+  const int totalFrames = 16;
+  int prev = bootTextXForFrame(0, totalFrames, 128, 120);
+  for (int f = 1; f < totalFrames; f++)
+  {
+    int x = bootTextXForFrame(f, totalFrames, 128, 120);
+    TEST_ASSERT_TRUE(x <= prev); // film never jitters back to the right
+    prev = x;
+  }
+}
+
+void test_boot_text_single_frame_guard()
+{
+  // Degenerate totalFrames must not divide by zero; returns the centered x.
+  TEST_ASSERT_EQUAL_INT((128 - 120) / 2, bootTextXForFrame(0, 1, 128, 120));
+}
+
+void test_boot_sprocket_offset_within_spacing_and_advances()
+{
+  const int step = 3;
+  const int spacing = 12;
+  for (int f = 0; f < 40; f++)
+  {
+    int off = bootSprocketOffsetForFrame(f, step, spacing);
+    TEST_ASSERT_TRUE(off >= 0 && off < spacing);
+    TEST_ASSERT_EQUAL_INT((f * step) % spacing, off);
+  }
+}
+
+void test_boot_sprocket_offset_spacing_guard()
+{
+  // Non-positive spacing must not modulo-by-zero.
+  TEST_ASSERT_EQUAL_INT(0, bootSprocketOffsetForFrame(5, 3, 0));
+}
+
 int main(int, char **)
 {
   UNITY_BEGIN();
@@ -1616,5 +1670,11 @@ int main(int, char **)
   RUN_TEST(test_ui_signature_hash_cstring_treats_null_as_empty);
   RUN_TEST(test_ui_signature_external_changes_when_any_field_changes);
   RUN_TEST(test_ui_signature_menu_changes_when_focus_or_distance_offset_changes);
+  RUN_TEST(test_boot_text_starts_offscreen_right);
+  RUN_TEST(test_boot_text_lands_centered_on_final_frame);
+  RUN_TEST(test_boot_text_is_monotonically_non_increasing);
+  RUN_TEST(test_boot_text_single_frame_guard);
+  RUN_TEST(test_boot_sprocket_offset_within_spacing_and_advances);
+  RUN_TEST(test_boot_sprocket_offset_spacing_guard);
   return UNITY_END();
 }

--- a/docs/superpowers/plans/2026-07-13-film-advance-boot-animation.md
+++ b/docs/superpowers/plans/2026-07-13-film-advance-boot-animation.md
@@ -425,14 +425,14 @@ Tags are annotated, not signed. No binary assets — the updater workflow builds
 ## Self-Review
 
 **Spec coverage:**
-- Animation on external display, film-advance, replaces static splash → Task 2 draw loop. ✓
-- Perforations present whole animation, version eases in from right to centre → Task 1 logic + Task 2 loop. ✓
-- Timing ~1000-1200 ms → Task 2 constants (640 + 400 ms). ✓
-- Logic/hardware split, pure host-tested module → Task 1. ✓
-- Test invariants (starts off-screen, monotonic, lands centred, sprocket wrap) → Task 1 tests. ✓
-- No prefs/schema change, preserve guard + u8g2_ext handoff → Task 2 function preserves both. ✓
-- Release 10.6.1: five version files + changelog + tag/release → Task 3. ✓
-- Out of scope (main display, toggle, sound) → not present. ✓
+- Animation on external display, film-advance, replaces static splash → Task 2 draw loop. Yes
+- Perforations present whole animation, version eases in from right to centre → Task 1 logic + Task 2 loop. Yes
+- Timing ~1000-1200 ms → Task 2 constants (640 + 400 ms). Yes
+- Logic/hardware split, pure host-tested module → Task 1. Yes
+- Test invariants (starts off-screen, monotonic, lands centred, sprocket wrap) → Task 1 tests. Yes
+- No prefs/schema change, preserve guard + u8g2_ext handoff → Task 2 function preserves both. Yes
+- Release 10.6.1: five version files + changelog + tag/release → Task 3. Yes
+- Out of scope (main display, toggle, sound) → not present. Yes
 
 **Placeholder scan:** No TBD/TODO; all steps have concrete code and commands. The `<merge-commit>` in Step 8 is a genuine post-merge value the maintainer supplies, not a plan gap.
 

--- a/docs/superpowers/plans/2026-07-13-film-advance-boot-animation.md
+++ b/docs/superpowers/plans/2026-07-13-film-advance-boot-animation.md
@@ -1,0 +1,439 @@
+# Film-Advance Boot Animation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the static external-display boot splash with a silly film-advance animation that feeds the `MRF X.Y.Z` version in from the right, and ship it as firmware 10.6.1.
+
+**Architecture:** A new pure-logic module computes per-frame geometry (eased text x-offset, wrapped sprocket offset) and is host-unit-tested. The draw loop in `main.cpp`'s existing `showBootScreenOnExternalDisplay()` calls that logic and renders rectangles + text to the 128x32 SSD1306, keeping the hardware code thin. Timing constants live in `mrfconstants.h`.
+
+**Tech Stack:** C++ (Arduino/ESP32-S3), Adafruit_SSD1306 for the external OLED, PlatformIO, Unity host tests (`native_core_tests`).
+
+## Global Constraints
+
+- External display is 128 wide x 32 tall, monochrome (`SCREEN_WIDTH` = 128, `SCREEN_HEIGHT_EXT` = 32).
+- Pure-logic modules must be host-compilable: no Arduino/Adafruit types in `boot_animation_logic.*`.
+- No `Co-Authored-By: Claude` or any AI trailer in commits. Human-style commit subjects, no AI tells, no emoji.
+- Do NOT add `setFrameRate`-style side effects; this change touches display only.
+- No prefs / NVS schema change; do not bump `PREFS_SCHEMA_VERSION`.
+- Preserve the `hardware.externalDisplay` guard and the `u8g2_ext.begin(display_ext)` handoff at the end of the boot screen.
+- Total animation (moving frames + end hold) must stay ~1000-1200 ms so boot feels no slower.
+- Release version is exactly `10.6.1`; date `2026-07-13`.
+
+---
+
+### Task 1: Pure boot-animation geometry logic + host tests
+
+**Files:**
+- Create: `Firmware/include/boot_animation_logic.h`
+- Create: `Firmware/src/boot_animation_logic.cpp`
+- Test: `Firmware/test/test_core_logic_regression/test_main.cpp` (add include + cases)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth);`
+  - `int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx);`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add near the other logic includes at the top of `Firmware/test/test_core_logic_regression/test_main.cpp`:
+
+```cpp
+#include "boot_animation_logic.h"
+```
+
+And with the other `#include "../../src/*.cpp"` lines:
+
+```cpp
+#include "../../src/boot_animation_logic.cpp"
+```
+
+Add these test functions (place them alongside the existing `test_*` functions):
+
+```cpp
+void test_boot_text_starts_offscreen_right()
+{
+  // Frame 0: the version text begins fully off the right edge of the display.
+  TEST_ASSERT_TRUE(bootTextXForFrame(0, 16, 128, 120) >= 128);
+}
+
+void test_boot_text_lands_centered_on_final_frame()
+{
+  const int totalFrames = 16;
+  const int displayWidth = 128;
+  const int textWidth = 120;
+  int expectedCentered = (displayWidth - textWidth) / 2; // 4
+  TEST_ASSERT_EQUAL_INT(expectedCentered,
+                        bootTextXForFrame(totalFrames - 1, totalFrames, displayWidth, textWidth));
+}
+
+void test_boot_text_is_monotonically_non_increasing()
+{
+  const int totalFrames = 16;
+  int prev = bootTextXForFrame(0, totalFrames, 128, 120);
+  for (int f = 1; f < totalFrames; f++)
+  {
+    int x = bootTextXForFrame(f, totalFrames, 128, 120);
+    TEST_ASSERT_TRUE(x <= prev); // film never jitters back to the right
+    prev = x;
+  }
+}
+
+void test_boot_text_single_frame_guard()
+{
+  // Degenerate totalFrames must not divide by zero; returns the centered x.
+  TEST_ASSERT_EQUAL_INT((128 - 120) / 2, bootTextXForFrame(0, 1, 128, 120));
+}
+
+void test_boot_sprocket_offset_within_spacing_and_advances()
+{
+  const int step = 3;
+  const int spacing = 12;
+  for (int f = 0; f < 40; f++)
+  {
+    int off = bootSprocketOffsetForFrame(f, step, spacing);
+    TEST_ASSERT_TRUE(off >= 0 && off < spacing);
+    TEST_ASSERT_EQUAL_INT((f * step) % spacing, off);
+  }
+}
+
+void test_boot_sprocket_offset_spacing_guard()
+{
+  // Non-positive spacing must not modulo-by-zero.
+  TEST_ASSERT_EQUAL_INT(0, bootSprocketOffsetForFrame(5, 3, 0));
+}
+```
+
+Register them in the Unity `RUN_TEST(...)` block (inside `main()` / the runner where the other `RUN_TEST` calls live):
+
+```cpp
+RUN_TEST(test_boot_text_starts_offscreen_right);
+RUN_TEST(test_boot_text_lands_centered_on_final_frame);
+RUN_TEST(test_boot_text_is_monotonically_non_increasing);
+RUN_TEST(test_boot_text_single_frame_guard);
+RUN_TEST(test_boot_sprocket_offset_within_spacing_and_advances);
+RUN_TEST(test_boot_sprocket_offset_spacing_guard);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pio test -e native_core_tests -f test_core_logic_regression`
+Expected: FAIL to compile / link with an error about `boot_animation_logic.h` not found or `bootTextXForFrame` undefined.
+
+- [ ] **Step 3: Write the header**
+
+Create `Firmware/include/boot_animation_logic.h`:
+
+```cpp
+#ifndef BOOT_ANIMATION_LOGIC_H
+#define BOOT_ANIMATION_LOGIC_H
+
+// Pure geometry for the external-display film-advance boot animation.
+// No Arduino/Adafruit types so it can be unit-tested on the host.
+
+// Eased left-edge x (px) of the version text for a given animation frame.
+// The film feeds in from the right: frame 0 starts fully off-screen
+// (x == displayWidth) and the sequence eases out to the centered x on the
+// final frame (frame == totalFrames - 1). Monotonically non-increasing.
+// frame is clamped to [0, totalFrames - 1]; totalFrames <= 1 returns centered.
+int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth);
+
+// Wrapped x-offset (0..spacingPx-1) of the sprocket perforations for a frame,
+// advancing by stepPx each frame so the film reads as moving left.
+// spacingPx <= 0 returns 0.
+int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx);
+
+#endif // BOOT_ANIMATION_LOGIC_H
+```
+
+- [ ] **Step 4: Write the implementation**
+
+Create `Firmware/src/boot_animation_logic.cpp`:
+
+```cpp
+#include "boot_animation_logic.h"
+
+int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth)
+{
+  const int centered = (displayWidth - textWidth) / 2;
+  if (totalFrames <= 1)
+  {
+    return centered;
+  }
+  if (frame < 0)
+  {
+    frame = 0;
+  }
+  if (frame > totalFrames - 1)
+  {
+    frame = totalFrames - 1;
+  }
+
+  const long last = totalFrames - 1;
+  const int start = displayWidth;            // fully off the right edge
+  const long span = (long)(centered - start); // negative: text moves left
+
+  // Ease-out: eased = 1 - (1 - p)^2, with p = frame / last.
+  // easedNumerator / (last*last) == eased, kept in integer math.
+  const long remaining = last - frame;
+  const long easedNumerator = last * last - remaining * remaining;
+
+  return start + (int)(span * easedNumerator / (last * last));
+}
+
+int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx)
+{
+  if (spacingPx <= 0)
+  {
+    return 0;
+  }
+  long off = ((long)frame * stepPx) % spacingPx;
+  if (off < 0)
+  {
+    off += spacingPx;
+  }
+  return (int)off;
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pio test -e native_core_tests -f test_core_logic_regression`
+Expected: PASS — all existing tests plus the six new ones.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Firmware/include/boot_animation_logic.h Firmware/src/boot_animation_logic.cpp Firmware/test/test_core_logic_regression/test_main.cpp
+git commit -m "Add boot animation geometry logic with host tests"
+```
+
+---
+
+### Task 2: Constants + film-advance draw loop in main.cpp
+
+**Files:**
+- Modify: `Firmware/include/mrfconstants.h` (add animation constants; retune `DISPLAY_BOOT_SCREEN_MS`)
+- Modify: `Firmware/src/main.cpp` (include header; replace body of `showBootScreenOnExternalDisplay()`)
+
+**Interfaces:**
+- Consumes: `bootTextXForFrame`, `bootSprocketOffsetForFrame` from Task 1.
+- Produces: animated boot screen; no new public symbols.
+
+- [ ] **Step 1: Add constants**
+
+In `Firmware/include/mrfconstants.h`, next to the existing `DISPLAY_BOOT_SCREEN_MS` / `DISPLAY_BOOT_TEXT_SIZE` lines (around line 68-77), change the hold and add the animation constants:
+
+```cpp
+const unsigned long DISPLAY_BOOT_SCREEN_MS = 400;      // Post-landing hold after the film settles.
+const int DISPLAY_BOOT_ANIM_FRAMES = 16;               // Number of animated film-advance frames.
+const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 40;   // Delay per animation frame (16*40 = 640 ms).
+const int DISPLAY_BOOT_SPROCKET_SPACING = 12;          // Px between sprocket-hole centres.
+const int DISPLAY_BOOT_SPROCKET_STEP = 3;              // Px the perforations shift per frame.
+const int DISPLAY_BOOT_SPROCKET_W = 6;                 // Sprocket-hole width in px.
+const int DISPLAY_BOOT_SPROCKET_H = 4;                 // Sprocket-hole height (top and bottom bands).
+```
+
+(Total ~640 ms moving + 400 ms hold = ~1040 ms, within the 1000-1200 ms budget.)
+
+- [ ] **Step 2: Include the logic header in main.cpp**
+
+In `Firmware/src/main.cpp`, add to the include block (after `#include "mrfconstants.h"`):
+
+```cpp
+#include "boot_animation_logic.h"
+```
+
+- [ ] **Step 3: Replace the body of showBootScreenOnExternalDisplay()**
+
+Replace the current function body (the version-sizing loop through the final clear) so it keeps the largest-fits-width sizing, then animates. The full function becomes:
+
+```cpp
+void showBootScreenOnExternalDisplay()
+{
+  if (!hardware.externalDisplay)
+  {
+    return;
+  }
+
+  display_ext.clearDisplay();
+  display_ext.setTextColor(SSD1306_WHITE);
+
+  char bootText[24];
+  snprintf(bootText, sizeof(bootText), "MRF %s", FWVERSION);
+
+  // Pick the largest text size (up to the preferred one) that fits the display
+  // width, so a longer version string (e.g. 10.6.10) can't wrap on the narrow
+  // external screen.
+  int16_t bootTextX1 = 0;
+  int16_t bootTextY1 = 0;
+  uint16_t bootTextWidth = 0;
+  uint16_t bootTextHeight = 0;
+  for (int bootTextSize = DISPLAY_BOOT_TEXT_SIZE; bootTextSize >= 1; bootTextSize--)
+  {
+    display_ext.setTextSize(static_cast<uint8_t>(bootTextSize));
+    display_ext.getTextBounds(bootText, 0, 0, &bootTextX1, &bootTextY1, &bootTextWidth, &bootTextHeight);
+    if (static_cast<int16_t>(bootTextWidth) <= display_ext.width())
+    {
+      break;
+    }
+  }
+
+  const int16_t bootCursorY =
+      ((display_ext.height() - static_cast<int16_t>(bootTextHeight)) / 2) - bootTextY1;
+
+  // Film-advance animation: perforations tick left along the top and bottom
+  // edges while the version rides in from the right and eases to centre.
+  for (int frame = 0; frame < DISPLAY_BOOT_ANIM_FRAMES; frame++)
+  {
+    display_ext.clearDisplay();
+
+    const int sprocketOffset =
+        bootSprocketOffsetForFrame(frame, DISPLAY_BOOT_SPROCKET_STEP, DISPLAY_BOOT_SPROCKET_SPACING);
+    for (int x = sprocketOffset - DISPLAY_BOOT_SPROCKET_SPACING; x < display_ext.width();
+         x += DISPLAY_BOOT_SPROCKET_SPACING)
+    {
+      display_ext.fillRect(x, 0, DISPLAY_BOOT_SPROCKET_W, DISPLAY_BOOT_SPROCKET_H, SSD1306_WHITE);
+      display_ext.fillRect(x, display_ext.height() - DISPLAY_BOOT_SPROCKET_H,
+                           DISPLAY_BOOT_SPROCKET_W, DISPLAY_BOOT_SPROCKET_H, SSD1306_WHITE);
+    }
+
+    const int textX = bootTextXForFrame(frame, DISPLAY_BOOT_ANIM_FRAMES,
+                                        display_ext.width(), static_cast<int>(bootTextWidth));
+    display_ext.setCursor(static_cast<int16_t>(textX) - bootTextX1, bootCursorY);
+    display_ext.print(bootText);
+
+    display_ext.display();
+    delay(DISPLAY_BOOT_ANIM_FRAME_MS);
+  }
+
+  // Hold the settled frame, then clear and hand the panel to u8g2_ext as before.
+  delay(DISPLAY_BOOT_SCREEN_MS);
+
+  u8g2_ext.begin(display_ext);
+  display_ext.clearDisplay();
+  display_ext.display();
+}
+```
+
+- [ ] **Step 4: Build the firmware**
+
+Run: `pio run -e adafruit_feather_esp32s3`
+Expected: SUCCESS, no new `-Wall -Wextra` warnings from the changed code.
+
+- [ ] **Step 5: Re-run host tests (regression guard)**
+
+Run: `pio test -e native_core_tests`
+Expected: PASS (unchanged; confirms the constants edit didn't break anything).
+
+- [ ] **Step 6: On-device verification**
+
+Flash a board (`pio run -e adafruit_feather_esp32s3 --target upload`) and watch the external display at power-on: perforations tick left, `MRF 10.6.0`/current version rides in from the right and settles centred, boot feels no slower than before. (Version string updates to 10.6.1 in Task 3.)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Firmware/include/mrfconstants.h Firmware/src/main.cpp
+git commit -m "Animate external boot splash as a film-advance sequence"
+```
+
+---
+
+### Task 3: Version bump to 10.6.1 + docs + release
+
+**Files:**
+- Modify: `Firmware/include/mrfconstants.h:9`
+- Modify: `Firmware/README.md:3`
+- Modify: `Firmware/CHANGELOG.md` (new top section)
+- Modify: `Documentation/user-manual/USER_MANUAL.md:3`
+- Modify: `Documentation/user-manual/images/config-ui.svg:15`
+
+**Interfaces:**
+- Consumes: the feature from Tasks 1-2.
+- Produces: a tagged, released 10.6.1.
+
+- [ ] **Step 1: Bump the firmware version constant**
+
+In `Firmware/include/mrfconstants.h` line 9:
+
+```cpp
+#define FWVERSION "10.6.1"                   // Version shown in UI and release metadata.
+```
+
+- [ ] **Step 2: Bump README**
+
+In `Firmware/README.md` line 3:
+
+```markdown
+**Version**: 10.6.1
+```
+
+- [ ] **Step 3: Bump user manual**
+
+In `Documentation/user-manual/USER_MANUAL.md` line 3:
+
+```markdown
+**Firmware version:** 10.6.1
+```
+
+- [ ] **Step 4: Update the on-screen version label in the SVG**
+
+In `Documentation/user-manual/images/config-ui.svg` line 15, change the version at the end of the text node:
+
+```xml
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.1</text>
+```
+
+- [ ] **Step 5: Add the CHANGELOG section**
+
+In `Firmware/CHANGELOG.md`, insert this new section immediately above `## 10.6.0 - 2026-07-13`:
+
+```markdown
+## 10.6.1 - 2026-07-13
+
+### External display boot animation
+
+- Replaced the static `MRF X.Y.Z` boot splash on the external OLED with a film-advance animation: sprocket perforations tick along the top and bottom edges while the version rides in from the right and settles centred, like loading a fresh roll. The per-frame geometry lives in a new host-tested `boot_animation_logic` module; the draw loop stays thin. Boot timing is unchanged (~1 s). Verify boot timing and legibility on device.
+```
+
+- [ ] **Step 6: Verify the version appears consistently**
+
+Run: `grep -rn "10.6.1" Firmware/include/mrfconstants.h Firmware/README.md Firmware/CHANGELOG.md Documentation/user-manual/USER_MANUAL.md Documentation/user-manual/images/config-ui.svg`
+Expected: one match in each of the five files.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Firmware/include/mrfconstants.h Firmware/README.md Firmware/CHANGELOG.md Documentation/user-manual/USER_MANUAL.md Documentation/user-manual/images/config-ui.svg
+git commit -m "Release firmware v10.6.1"
+```
+
+- [ ] **Step 8: Tag and release (after merge to main)**
+
+These run once the branch is merged. Confirm with the maintainer before pushing.
+
+```bash
+git tag -a v10.6.1 <merge-commit> -m "Firmware v10.6.1"
+git push origin v10.6.1
+gh release create v10.6.1 --title "Firmware v10.6.1" --notes-file <(sed -n '/## 10.6.1/,/## 10.6.0/p' Firmware/CHANGELOG.md | sed '$d')
+```
+
+Tags are annotated, not signed. No binary assets — the updater workflow builds from `main`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Animation on external display, film-advance, replaces static splash → Task 2 draw loop. ✓
+- Perforations present whole animation, version eases in from right to centre → Task 1 logic + Task 2 loop. ✓
+- Timing ~1000-1200 ms → Task 2 constants (640 + 400 ms). ✓
+- Logic/hardware split, pure host-tested module → Task 1. ✓
+- Test invariants (starts off-screen, monotonic, lands centred, sprocket wrap) → Task 1 tests. ✓
+- No prefs/schema change, preserve guard + u8g2_ext handoff → Task 2 function preserves both. ✓
+- Release 10.6.1: five version files + changelog + tag/release → Task 3. ✓
+- Out of scope (main display, toggle, sound) → not present. ✓
+
+**Placeholder scan:** No TBD/TODO; all steps have concrete code and commands. The `<merge-commit>` in Step 8 is a genuine post-merge value the maintainer supplies, not a plan gap.
+
+**Type consistency:** `bootTextXForFrame` / `bootSprocketOffsetForFrame` signatures identical across header (Task 1), tests (Task 1), and call sites (Task 2). Constant names (`DISPLAY_BOOT_ANIM_FRAMES`, `DISPLAY_BOOT_ANIM_FRAME_MS`, `DISPLAY_BOOT_SPROCKET_SPACING`, `DISPLAY_BOOT_SPROCKET_STEP`, `DISPLAY_BOOT_SPROCKET_W`, `DISPLAY_BOOT_SPROCKET_H`, `DISPLAY_BOOT_SCREEN_MS`) match between Task 2 Step 1 and Step 3.

--- a/docs/superpowers/specs/2026-07-13-film-advance-boot-animation-design.md
+++ b/docs/superpowers/specs/2026-07-13-film-advance-boot-animation-design.md
@@ -1,0 +1,123 @@
+# Film-advance boot animation (external display)
+
+**Date:** 2026-07-13
+**Target version:** 10.6.1 (patch bump + tag + GitHub release)
+**Scope:** Firmware only. One new pure-logic module, one host unit test, a thin draw loop in `main.cpp`, a handful of constants, plus the standard release-file updates.
+
+## Goal
+
+Give the 128x32 external SSD1306 a silly-but-tasteful startup animation: a strip of
+perforated film feeds in from the right and carries the `MRF X.Y.Z` version into
+the centre, like loading a fresh roll. It fully replaces today's static splash and
+must not make boot feel slower.
+
+## Current behaviour (what we're replacing)
+
+`showBootScreenOnExternalDisplay()` in `Firmware/src/main.cpp` prints `MRF X.Y.Z`
+centred, holds it for `DISPLAY_BOOT_SCREEN_MS` (1000 ms) via a blocking `delay`,
+then clears the display and hands the panel to `u8g2_ext`. It is called once in
+`setup()` between `initializeMainDisplay()` and the LiDAR init step, guarded by
+`hardware.externalDisplay`.
+
+## Design
+
+### The animation (128 wide x 32 tall, monochrome)
+
+- **Sprocket perforations:** small white rectangles run along the top edge
+  (y 0..3) and bottom edge (y 28..31) at a fixed horizontal spacing. Each frame
+  their x positions shift left by a fixed step and wrap, so the film reads as
+  advancing through the gate. Perforations are present for the whole animation.
+- **Frame image (the "photo"):** the centre band (y ~8..24) carries the text
+  `MRF X.Y.Z`. It starts fully off the right edge and eases left to centred.
+- **Landing:** once the text is centred, perforations tick for a couple more
+  frames, then a short hold, then the display clears exactly as today and control
+  passes to `u8g2_ext`. Final visible state = version legibly centred (same info
+  a builder relies on today).
+
+### Timing
+
+Whole sequence targets ~1000-1200 ms so perceived boot time is unchanged. The
+existing `DISPLAY_BOOT_SCREEN_MS` is repurposed as the end-hold after landing (or
+reduced accordingly); the moving portion is `frameCount * frameDelayMs`. Concrete
+values live in constants (below) and are tuned so the total stays in budget.
+
+### Logic / hardware split (matches repo convention)
+
+New pure module `Firmware/src/boot_animation_logic.cpp` + `include/boot_animation_logic.h`,
+host-testable, no Arduino/Adafruit types. It computes, given a frame index and the
+display width, the per-frame geometry the draw loop needs. Proposed surface:
+
+```cpp
+// Eased horizontal offset (px) of the version text for a given frame.
+// Monotonically non-increasing; starts >= displayWidth (off-screen right),
+// ends at the centred x for the final animated frame.
+int bootTextXForFrame(int frame, int totalFrames, int displayWidth, int textWidth);
+
+// Wrapped horizontal offset (0..spacing-1) of the sprocket holes for a frame.
+int bootSprocketOffsetForFrame(int frame, int stepPx, int spacingPx);
+```
+
+Easing: a simple integer ease-out (e.g. offset proportional to
+`(totalFrames - frame)^2 / totalFrames^2 * startOffset`) so the film decelerates
+into place. Exact curve chosen during implementation; the test pins the
+invariants, not the precise pixels.
+
+The draw loop in `main.cpp` stays thin: for each frame, clear, draw top+bottom
+sprocket rects using `bootSprocketOffsetForFrame`, draw the version text at
+`bootTextXForFrame`, `display_ext.display()`, `delay(frameDelayMs)`. Version
+string is built once with the existing largest-fits-width sizing logic so long
+versions (e.g. `10.6.10`) still fit.
+
+### Constants (`Firmware/include/mrfconstants.h`)
+
+- `DISPLAY_BOOT_ANIM_FRAMES` — number of animated frames (e.g. 16).
+- `DISPLAY_BOOT_ANIM_FRAME_MS` — per-frame delay (e.g. 45 ms).
+- `DISPLAY_BOOT_SPROCKET_SPACING` — px between perforation centres (e.g. 12).
+- `DISPLAY_BOOT_SPROCKET_STEP` — px the perforations shift per frame (e.g. 3).
+- `DISPLAY_BOOT_SPROCKET_W` / `_H` — perforation rect size.
+- `DISPLAY_BOOT_SCREEN_MS` — retained, now the post-landing hold.
+
+### What does NOT change
+
+- No new boot step; the main-display progress bar is untouched.
+- No prefs / NVS schema change (no `PREFS_SCHEMA_VERSION` bump).
+- `hardware.externalDisplay` guard and the `u8g2_ext` handoff are preserved.
+- Graceful no-op when the external display is absent (early return, as today).
+
+## Testing
+
+Add cases to `Firmware/test/test_core_logic_regression/test_main.cpp` (include the
+new logic `.cpp` and header the same way the other logic modules are pulled in).
+Assert the invariants:
+
+- `bootTextXForFrame(0, ...)` >= displayWidth (text starts fully off-screen right).
+- Sequence is monotonically non-increasing across frames (never jitters right).
+- Final frame lands at the centred x: `(displayWidth - textWidth) / 2`.
+- `bootSprocketOffsetForFrame` stays within `[0, spacing)` and advances by `step`
+  each frame with correct wrap.
+
+Run: `pio test -e native_core_tests -f test_core_logic_regression`.
+Firmware build sanity: `pio run -e adafruit_feather_esp32s3`.
+On-hardware check: flash and confirm the film feeds in, version lands centred,
+boot feels no slower. Note "verify on device" in the CHANGELOG since timing is
+eyeballed, not measured.
+
+## Documentation & release (10.6.1)
+
+Per the repo release workflow, update all five version files:
+
+1. `Firmware/include/mrfconstants.h` -> `#define FWVERSION "10.6.1"`
+2. `Firmware/README.md` -> `**Version**: 10.6.1`
+3. `Firmware/CHANGELOG.md` -> new `## 10.6.1 - 2026-07-13` section describing the
+   boot animation, with a "verify boot timing on device" note.
+4. `Documentation/user-manual/USER_MANUAL.md` -> `**Firmware version:** 10.6.1`
+5. `Documentation/user-manual/images/config-ui.svg` -> on-screen version label.
+
+Then commit, push the branch, and after merge: annotated tag `v10.6.1`, GitHub
+release with the changelog section as the body (no binary assets).
+
+## Out of scope
+
+- Any animation on the main 128x128 display.
+- User-configurable / toggleable animation (YAGNI; it's a boot flourish).
+- Sound, per-format variations, or logo bitmaps.


### PR DESCRIPTION
Replaces the static "MRF X.Y.Z" splash on the external 128x32 OLED with a film-advance boot animation: sprocket perforations tick along the top and bottom edges while the version rides in from the right and eases to centre, like loading a fresh roll. The final frame is the version, centred, so it still shows the same information a builder relies on.

## What changed
- New pure `boot_animation_logic` module (host-tested) computes the per-frame geometry: an ease-out for the text x-offset and a wrapped offset for the perforations. The draw loop in `showBootScreenOnExternalDisplay()` stays thin.
- Boot timing is unchanged (~1.04 s: 16 frames x 40 ms + 400 ms hold), so power-on feels no slower.
- No prefs/NVS schema change; the external-display guard and the `u8g2_ext` handoff are preserved.
- Version bumped to 10.6.1 across all release files, including the Health screen mockup SVG.
- User manual now describes the boot animation.

## Testing
- `pio test -e native_core_tests` — 86/86 pass (6 new tests pin the animation invariants).
- `pio run -e adafruit_feather_esp32s3` — builds clean, no new warnings.
- On-device look and timing still to be eyeballed on hardware before wider distribution (noted in the CHANGELOG).
