### PR TITLE
Slow the boot animation (v10.6.2)

### DIFF
--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.6.1
+**Firmware version:** 10.6.2
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.1</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.2</text>
 </svg>

--- a/Documentation/user-manual/images/health-ui.svg
+++ b/Documentation/user-manual/images/health-ui.svg
@@ -2,7 +2,7 @@
   <rect x="0" y="0" width="128" height="128" fill="#000000" stroke="#ffffff" stroke-width="1"/>
   <text x="3" y="15" font-family="monospace" font-size="10" fill="#ffffff">System Health</text>
 
-  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.1</text>
+  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.2</text>
   <text x="4" y="40" font-family="monospace" font-size="6" fill="#ffffff">Prefs: v2 OK</text>
   <text x="4" y="50" font-family="monospace" font-size="6" fill="#ffffff">LiDAR: InitErr Off err:0</text>
   <text x="4" y="60" font-family="monospace" font-size="6" fill="#ffffff">Recoveries: 0</text>

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.6.2 - 2026-07-13
+
+### Slower boot animation
+
+- Slowed the external-display film-advance animation so the film feed is easier to watch: 20 frames at 80 ms plus a 500 ms settle hold (~2.1 s total, up from ~1 s). Timing only — no logic change. Verify the feel on device.
+
 ## 10.6.1 - 2026-07-13
 
 ### External display boot animation

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.6.1
+**Version**: 10.6.2
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.6.1"                   // Version shown in UI and release metadata.
+#define FWVERSION "10.6.2"                   // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------
@@ -66,9 +66,9 @@ const int NEOPIXEL_OFF_B = 0;                  // LED-off B channel.
 
 const unsigned long DISPLAY_INIT_DELAY_MS = 1000;      // Main display power-up settle delay.
 const unsigned long DISPLAY_EXT_INIT_DELAY_MS = 500;   // External display settle delay.
-const unsigned long DISPLAY_BOOT_SCREEN_MS = 400;      // Post-landing hold after the film settles.
-const int DISPLAY_BOOT_ANIM_FRAMES = 16;               // Number of animated film-advance frames.
-const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 40;   // Delay per animation frame (16*40 = 640 ms).
+const unsigned long DISPLAY_BOOT_SCREEN_MS = 500;      // Post-landing hold after the film settles.
+const int DISPLAY_BOOT_ANIM_FRAMES = 20;               // Number of animated film-advance frames.
+const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 80;   // Delay per animation frame (20*80 = 1600 ms).
 const int DISPLAY_BOOT_SPROCKET_SPACING = 12;          // Px between sprocket-hole centres.
 const int DISPLAY_BOOT_SPROCKET_STEP = 3;              // Px the perforations shift per frame.
 const int DISPLAY_BOOT_SPROCKET_W = 6;                 // Sprocket-hole width in px.


### PR DESCRIPTION
Slows the external-display film-advance boot animation so the film feed is easier to watch. Timing only, no logic change.

- 20 frames x 80 ms travel + 500 ms settle hold (~2.1 s total, up from ~1 s).
- Constants only, in `mrfconstants.h`: `DISPLAY_BOOT_ANIM_FRAMES`, `DISPLAY_BOOT_ANIM_FRAME_MS`, `DISPLAY_BOOT_SCREEN_MS`.
- Version bumped to 10.6.2 across all six release files.

Build clean; 86/86 host tests pass. Feel still to be confirmed on hardware.
