### PR TITLE
Fix boot-animation bottom-edge text artifacts, tune speed (v10.6.3)

### DIFF
--- a/Documentation/user-manual/USER_MANUAL.md
+++ b/Documentation/user-manual/USER_MANUAL.md
@@ -1,6 +1,6 @@
 # MRF2 User Manual
 
-**Firmware version:** 10.6.2
+**Firmware version:** 10.6.3
 
 This manual covers how to operate the MRF2 firmware user interface, including the on-device displays, buttons, calibration flow, and film counter behavior. It is written for everyday use, not just for builders.
 

--- a/Documentation/user-manual/images/config-ui.svg
+++ b/Documentation/user-manual/images/config-ui.svg
@@ -12,5 +12,5 @@
   <text x="4" y="71" font-family="monospace" font-size="6" fill="#ffffff"> System Health &gt; </text>
   <text x="4" y="80" font-family="monospace" font-size="6" fill="#ffffff"> Exit &gt;&gt; </text>
 
-  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.2</text>
+  <text x="3" y="121" font-family="monospace" font-size="6" fill="#ffffff"> IDENTIDEM.design MRF 10.6.3</text>
 </svg>

--- a/Documentation/user-manual/images/health-ui.svg
+++ b/Documentation/user-manual/images/health-ui.svg
@@ -2,7 +2,7 @@
   <rect x="0" y="0" width="128" height="128" fill="#000000" stroke="#ffffff" stroke-width="1"/>
   <text x="3" y="15" font-family="monospace" font-size="10" fill="#ffffff">System Health</text>
 
-  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.2</text>
+  <text x="4" y="30" font-family="monospace" font-size="6" fill="#ffffff">FW: 10.6.3</text>
   <text x="4" y="40" font-family="monospace" font-size="6" fill="#ffffff">Prefs: v2 OK</text>
   <text x="4" y="50" font-family="monospace" font-size="6" fill="#ffffff">LiDAR: InitErr Off err:0</text>
   <text x="4" y="60" font-family="monospace" font-size="6" fill="#ffffff">Recoveries: 0</text>

--- a/Firmware/CHANGELOG.md
+++ b/Firmware/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable firmware changes by released `FWVERSION`, reconstructed from git history.
 
+## 10.6.3 - 2026-07-13
+
+### Boot animation: fix bottom-edge text artifacts, tune speed
+
+- Fixed stray version-text glyphs painted along the bottom of the external display at the start of the boot animation. Adafruit_GFX text wrap was left at its default (on), so while the version sat off the right edge the cursor wrapped to the left edge one line lower and drew there. Text wrap is now disabled for the boot screen, so off-screen glyphs are clipped as intended.
+- Sped the animation up a little: per-frame delay 80 ms to 65 ms and the settle hold 500 ms to 400 ms (~1.7 s total, down from ~2.1 s). Verify the feel on device.
+
 ## 10.6.2 - 2026-07-13
 
 ### Slower boot animation

--- a/Firmware/README.md
+++ b/Firmware/README.md
@@ -1,6 +1,6 @@
 # MRF2 Firmware - Medium Format Rangefinder System
 
-**Version**: 10.6.2
+**Version**: 10.6.3
 **Platform**: ESP32-S3  
 **Framework**: Arduino (PlatformIO)
 

--- a/Firmware/include/mrfconstants.h
+++ b/Firmware/include/mrfconstants.h
@@ -6,7 +6,7 @@
 // ---------------------------------------------------------------------------
 // Firmware identity and boot behavior
 // ---------------------------------------------------------------------------
-#define FWVERSION "10.6.2"                   // Version shown in UI and release metadata.
+#define FWVERSION "10.6.3"                   // Version shown in UI and release metadata.
 const unsigned long SLEEP_BOOT_GRACE_MS = 15000; // Ignore sleep timer immediately after boot.
 
 // ---------------------------------------------------------------------------
@@ -66,9 +66,9 @@ const int NEOPIXEL_OFF_B = 0;                  // LED-off B channel.
 
 const unsigned long DISPLAY_INIT_DELAY_MS = 1000;      // Main display power-up settle delay.
 const unsigned long DISPLAY_EXT_INIT_DELAY_MS = 500;   // External display settle delay.
-const unsigned long DISPLAY_BOOT_SCREEN_MS = 500;      // Post-landing hold after the film settles.
+const unsigned long DISPLAY_BOOT_SCREEN_MS = 400;      // Post-landing hold after the film settles.
 const int DISPLAY_BOOT_ANIM_FRAMES = 20;               // Number of animated film-advance frames.
-const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 80;   // Delay per animation frame (20*80 = 1600 ms).
+const unsigned long DISPLAY_BOOT_ANIM_FRAME_MS = 65;   // Delay per animation frame (20*65 = 1300 ms).
 const int DISPLAY_BOOT_SPROCKET_SPACING = 12;          // Px between sprocket-hole centres.
 const int DISPLAY_BOOT_SPROCKET_STEP = 3;              // Px the perforations shift per frame.
 const int DISPLAY_BOOT_SPROCKET_W = 6;                 // Sprocket-hole width in px.

--- a/Firmware/src/main.cpp
+++ b/Firmware/src/main.cpp
@@ -145,6 +145,11 @@ void showBootScreenOnExternalDisplay()
 
   display_ext.clearDisplay();
   display_ext.setTextColor(SSD1306_WHITE);
+  // Text wrap must be off: the animation deliberately positions the version
+  // off the right edge at the start of the roll. With Adafruit_GFX's default
+  // wrap enabled, an off-screen cursor resets to x=0 one text line lower,
+  // painting stray glyphs along the bottom of the panel. Wrap off clips them.
+  display_ext.setTextWrap(false);
 
   char bootText[24];
   snprintf(bootText, sizeof(bootText), "MRF %s", FWVERSION);


### PR DESCRIPTION
Fixes a rendering bug in the boot animation and nudges its speed.

## Bug: stray text at the bottom edge
At the start of the roll the version text is positioned off the right edge of the display. Adafruit_GFX's text wrap defaults to on, so an off-screen cursor was reset to x=0 one text line lower and drew the glyphs there, leaving artifacts along the bottom of the 32px panel. Fix: `display_ext.setTextWrap(false)` for the boot screen, so off-screen glyphs are clipped as intended.

## Speed
A little quicker: per-frame delay 80 ms to 65 ms, settle hold 500 ms to 400 ms (~1.7 s total, down from ~2.1 s).

Constants only in `mrfconstants.h` plus the one-line wrap fix. Version bumped to 10.6.3 across all six release files. Build clean; 86/86 host tests pass. Feel and the artifact fix to be confirmed on hardware.
